### PR TITLE
Fixes various mob saving bugs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -48,7 +48,8 @@
 
 /mob/Initialize()
 	. = ..()
-	skillset = new skillset(src)
+	if(ispath(skillset))
+		skillset = new skillset(src)
 	if(!move_intent)
 		move_intent = move_intents[1]
 	if(ispath(move_intent))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -48,8 +48,7 @@
 
 /mob/Initialize()
 	. = ..()
-	if(ispath(skillset))
-		skillset = new skillset(src)
+	skillset = new skillset(src)
 	if(!move_intent)
 		move_intent = move_intents[1]
 	if(ispath(move_intent))

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -65,6 +65,7 @@
 #include "modules\mob\mob.dm"
 #include "modules\mob\new_player.dm"
 #include "modules\mob\language\cortical.dm"
+#include "modules\mob\living\inventory.dm"
 #include "modules\mob\living\living.dm"
 #include "modules\mob\living\carbon\human\_defines.dm"
 #include "modules\mob\living\carbon\human\human.dm"

--- a/mods/persistence/modules/mob/living/carbon/human/human.dm
+++ b/mods/persistence/modules/mob/living/carbon/human/human.dm
@@ -1,11 +1,35 @@
 /mob/living/carbon/human
 	var/obj/home_spawn		// The object we last safe-slept on. Used for moving characters to safe locations on loads.
+	var/saved_species		// Whatever species we were, so that everything isn't rebuilt on load.
 
-/mob/living/carbon/human/after_deserialize()
-	// This refreshes/rebuilds the UI.
+/mob/living/carbon/human/Initialize()
+	if(ispath(move_intent))
+		move_intent = decls_repository.get_decl(move_intent)
+	if(saved_species)
+		species = get_species_by_key(saved_species)
+
+	..()
+
+	return INITIALIZE_HINT_LATELOAD
+
+/mob/living/carbon/human/LateInitialize()
+	. = ..()
+	
 	for(var/obj/item/I in contents)
 		I.hud_layerise()
+
+	// Refresh the items in contents to make sure they show up.
+	for(var/s in species.hud.gear)
+		var/list/gear = species.hud.gear[s]
+		var/obj/item/I = get_equipped_item(gear["slot"])
+		if(istype(I))
+			I.screen_loc = gear["loc"]
+
+	regenerate_icons()
+
+/mob/living/carbon/human/before_save()
 	. = ..()
+	if(species) saved_species = species.name // Caching species key for reference on load.
 
 // For granting cortical chat on character creation.
 /mob/living/carbon/human/update_languages()	

--- a/mods/persistence/modules/mob/living/inventory.dm
+++ b/mods/persistence/modules/mob/living/inventory.dm
@@ -1,0 +1,8 @@
+// Hands rebuild their slots on load. Reequip items that were held before hand.
+/mob/living/add_held_item_slot(var/slot, var/new_ui_loc, var/new_overlay_slot, var/new_label)  
+	var/obj/item/held = get_equipped_item(slot)
+
+	. = ..()	
+
+	if(held)
+		equip_to_slot_or_store_or_drop(held, slot)

--- a/mods/persistence/modules/mob/mob.dm
+++ b/mods/persistence/modules/mob/mob.dm
@@ -4,3 +4,13 @@
 /mob/before_save()
 	. = ..()
 	saved_ckey = ckey
+
+/mob/Initialize()
+	if(!ispath(skillset))
+		var/datum/skillset/temp = skillset
+		skillset = /datum/skillset
+		. = ..()
+		skillset = temp
+	else
+		. = ..()
+	

--- a/mods/persistence/saved_vars.json
+++ b/mods/persistence/saved_vars.json
@@ -24,7 +24,8 @@
 			"SE",
 			"b_type",
 			"real_name",
-			"lineage"
+			"lineage",
+			"species"
 		]
 	},
 	{
@@ -3048,7 +3049,8 @@
 			"saved_ckey",
 			"home_spawn",
 			"stance_limbs",
-			"grasp_limbs"
+			"grasp_limbs",
+			"saved_species"
 		]
 	},
 	{

--- a/mods/persistence/saved_vars.json
+++ b/mods/persistence/saved_vars.json
@@ -276,7 +276,14 @@
 			"job",
 			"maxHealth",
 			"health",
-			"last_special"
+			"last_special",
+			"meat_type",
+			"meat_amount",
+			"skin_material",
+			"skin_amount",
+			"bone_material",
+			"bone_amount",
+			"available_maneuvers"
 		]
 	},
 	{


### PR DESCRIPTION
Fixes a few mob saving bugs. HUDs were not properly rebuilt on load, as items did not have their screen location saved. Now on load players loop over their item slots and make sure everything is in its proper, clickable space. There's a similar fix for hand slots, since they uniquely rebuild on load due to reinitialization of hands.

Also fixed is clothes actually remaining on the mob when loaded. Mobs previously rebuilt their species on load, which removed all clothing items. Now the players do not have their species var saved, but do have the type cached, and will not have set_species called on them at load. Most vars that set_species would (re)set save correctly already, although blood/metabolism likely needs some more testing.

Finally, fixes mobs not processing on load due to a runtime in their Initialization proc, as skillset was an instance rather than the expected path. My solution for this was just to add an ispath() check outside of the Persistence modpack, but if this is unacceptable, I'm sure another solution could be chewed on. Since we're in a bit of a time crunch, I think it's appropriate to make minor adjustments like this, as the alternatives usually require far more overloads than is really ideal. Still, it's up for debate, and I'm happy to change it if requested.