### PR TITLE
Adds fusion thruster design to imprinter

### DIFF
--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -254,6 +254,9 @@
 /datum/fabricator_recipe/imprinter/circuit/thruster
 	path = /obj/item/stock_parts/circuitboard/unary_atmos/engine
 
+/datum/fabricator_recipe/imprinter/circuit/thruster_fusion
+	path = /obj/item/stock_parts/circuitboard/unary_atmos/fusion_engine
+
 /datum/fabricator_recipe/imprinter/circuit/helms
 	path = /obj/item/stock_parts/circuitboard/helm
 

--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -254,9 +254,6 @@
 /datum/fabricator_recipe/imprinter/circuit/thruster
 	path = /obj/item/stock_parts/circuitboard/unary_atmos/engine
 
-/datum/fabricator_recipe/imprinter/circuit/thruster_fusion
-	path = /obj/item/stock_parts/circuitboard/unary_atmos/fusion_engine
-
 /datum/fabricator_recipe/imprinter/circuit/helms
 	path = /obj/item/stock_parts/circuitboard/helm
 

--- a/mods/persistence/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/mods/persistence/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -1,0 +1,2 @@
+/datum/fabricator_recipe/imprinter/circuit/thruster_fusion
+	path = /obj/item/stock_parts/circuitboard/unary_atmos/fusion_engine


### PR DESCRIPTION
There's this cool fusion thruster that ties in nicely with the fusion engine but isn't actually available to be made, because no circuit design.
This adds the circuit design to the circuit imprinter, because what's the point of having these cool toys if players can't use them?
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
rscadd: The fusion thruster is now printable! Wooooo! Boosts the heat of your gas mix by drawing from a nearby fusion core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
