### PR TITLE
Makes PDAs buildable

### DIFF
--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -138,6 +138,11 @@
 	result_type = /obj/item/modular_computer/tablet
 	difficulty = 2
 
+/datum/stack_recipe/computer/PDA
+	title = "modular PDA frame"
+	result_type = /obj/item/modular_computer/pda
+	difficulty = 2
+
 /datum/stack_recipe/hazard_cone
 	title = "hazard cone"
 	result_type = /obj/item/caution/cone

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -138,11 +138,6 @@
 	result_type = /obj/item/modular_computer/tablet
 	difficulty = 2
 
-/datum/stack_recipe/computer/PDA
-	title = "modular PDA frame"
-	result_type = /obj/item/modular_computer/pda
-	difficulty = 2
-
 /datum/stack_recipe/hazard_cone
 	title = "hazard cone"
 	result_type = /obj/item/caution/cone

--- a/mods/persistence/modules/materials/recipes_items.dm
+++ b/mods/persistence/modules/materials/recipes_items.dm
@@ -1,0 +1,4 @@
+/datum/stack_recipe/computer/PDA
+	title = "modular PDA frame"
+	result_type = /obj/item/modular_computer/pda
+	difficulty = 2


### PR DESCRIPTION
PDAs are extremely handy. They're the only portable modular computer that can hold a credstick slot. This makes them buildable, as they should be.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
rscadd: You can build PDAs now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
