### PR TITLE
Adds solar tracker electronics to the autolathe.

### DIFF
--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -102,6 +102,9 @@
 /datum/fabricator_recipe/engineering/solars
 	path = /obj/item/solar_assembly
 
+/datum/fabricator_recipe/engineering/tracker_electronics
+	path = /obj/item/tracker_electronics
+
 /datum/fabricator_recipe/engineering/power_sensor
 	path = /obj/item/machine_chassis/power_sensor
 

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -76,7 +76,8 @@
 
 /obj/item/tracker_electronics
 
-	name = "tracker electronics"
+	name = "solar tracker electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_electronics"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/fiberglass


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->
Solar tracker electronics weren't able to be printed in any fabricator.
This allows solar tracker electronics to be printed from the autolathe. 
## Changelog
:cl:
rscadd: Solar tracker electronics are now printable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
