### PR TITLE
Revert "Makes PDAs buildable"

### DIFF
--- a/mods/persistence/modules/materials/recipes_items.dm
+++ b/mods/persistence/modules/materials/recipes_items.dm
@@ -1,4 +1,0 @@
-/datum/stack_recipe/computer/PDA
-	title = "modular PDA frame"
-	result_type = /obj/item/modular_computer/pda
-	difficulty = 2


### PR DESCRIPTION
Reverts PersistentSS13/Nebula#191

Whoops this did nothing because of how populating recipe lists works. I'm going to PR this upstream and wait for it to port over.