### PR TITLE
Removes clothing from biogenerator

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -36,18 +36,6 @@
 			/obj/item/chems/glass/bottle/left4zed = 120,
 			/obj/item/chems/glass/bottle/robustharvest = 120),
 		"Leather" = list(
-			/obj/item/storage/wallet/leather = 100,
-			/obj/item/clothing/gloves/thick/botany = 250,
-			/obj/item/storage/belt/utility = 300,
-			/obj/item/storage/backpack/satchel = 400,
-			/obj/item/storage/bag/cash = 400,
-			/obj/item/clothing/shoes/workboots = 400,
-			/obj/item/clothing/shoes/craftable = 400,
-			/obj/item/clothing/shoes/dress = 400,
-			/obj/item/clothing/suit/leathercoat = 500,
-			/obj/item/clothing/suit/storage/toggle/brown_jacket = 500,
-			/obj/item/clothing/suit/storage/toggle/bomber = 500,
-			/obj/item/clothing/suit/storage/hooded/wintercoat = 500,
 			/obj/item/stack/material/bolt/mapped/cloth/ten = 300,
 			/obj/item/stack/material/bolt/mapped/cloth = 30,
 			/obj/item/stack/material/skin/mapped/leather/ten = 300,
@@ -201,7 +189,7 @@
 		var/amt = REAGENT_VOLUME(I.reagents, /decl/material/liquid/nutriment)
 		if(amt < 0.1)
 			points += 1
-		else 
+		else
 			points += amt * 10 * eat_eff
 		qdel(I)
 	if(S)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -13,6 +13,7 @@
 	max_w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 	open_sound = 'sound/effects/storage/unzip.ogg'
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/backpack/equipped()
 	if(!has_extension(src, /datum/extension/appearance))
@@ -167,6 +168,7 @@
 	icon = 'icons/obj/items/storage/backpack/dufflebag.dmi'
 	w_class = ITEM_SIZE_HUGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/backpack/dufflebag/Initialize()
 	. = ..()
@@ -233,6 +235,7 @@
 	name = "satchel"
 	desc = "A trendy looking satchel."
 	icon = 'icons/obj/items/storage/backpack/satchel.dmi'
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/backpack/satchel/grey
 	name = "grey satchel"
@@ -379,7 +382,7 @@
 		var/image/I = image(icon, "[ret.icon_state]-[marking_state]")
 		I.color = marking_colour
 		I.appearance_flags |= RESET_COLOR
-		ret.add_overlay(I)	
+		ret.add_overlay(I)
 	return ret
 
 /obj/item/storage/backpack/ert/commander
@@ -414,6 +417,7 @@
 	name = "messenger bag"
 	desc = "A sturdy backpack worn over one shoulder."
 	icon = 'icons/obj/items/storage/backpack/messenger.dmi'
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/backpack/messenger/chem
 	name = "pharmacy messenger bag"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -110,3 +110,4 @@
 	max_w_class = ITEM_SIZE_HUGE
 	w_class = ITEM_SIZE_SMALL
 	can_hold = list(/obj/item/coin, /obj/item/cash)
+	material = /decl/material/solid/leather/synth

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -126,6 +126,7 @@
 		/obj/item/hand_labeler,
 		/obj/item/clothing/gloves
 		)
+	material = /decl/material/solid/leather
 
 /obj/item/storage/belt/utility/full/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -58,6 +58,13 @@
 		/obj/item/storage/box/syndie_kit/chameleon,
 		/obj/item/gun/energy/chameleon,
 		)
+	material = /decl/material/solid/metal/gold
+	matter = list(
+		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/uranium = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/fiberglass = MATTER_AMOUNT_TRACE
+	)
 
 /obj/item/storage/box/syndie_kit/chameleon
 	startswith = list(

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -42,6 +42,7 @@
 		/obj/item/clothing/accessory/armor/tag,
 		)
 	slot_flags = SLOT_ID
+	material = /decl/material/solid/leather
 
 	var/obj/item/card/id/front_id = null
 	var/obj/item/charge_stick/front_stick = null

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -73,6 +73,7 @@
 	name = "winter coat"
 	desc = "A heavy jacket made from 'synthetic' animal furs."
 	icon = 'icons/clothing/suit/wintercoat/coat.dmi'
+	material = /decl/material/solid/cloth
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_ARMS
 	cold_protection = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
@@ -97,10 +98,10 @@
 	name = "captain's winter coat"
 	icon = 'icons/clothing/suit/wintercoat/captain.dmi'
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_SMALL, 
-		energy = ARMOR_ENERGY_MINOR, 
+		melee = ARMOR_MELEE_KNIVES,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 		)
 
@@ -108,10 +109,10 @@
 	name = "security winter coat"
 	icon = 'icons/clothing/suit/wintercoat/sec.dmi'
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, 
-		bullet = ARMOR_BALLISTIC_SMALL, 
-		laser = ARMOR_LASER_SMALL, 
-		energy = ARMOR_ENERGY_MINOR, 
+		melee = ARMOR_MELEE_KNIVES,
+		bullet = ARMOR_BALLISTIC_SMALL,
+		laser = ARMOR_LASER_SMALL,
+		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_MINOR
 		)
 

--- a/code/modules/fabrication/designs/textile/overwear.dm
+++ b/code/modules/fabrication/designs/textile/overwear.dm
@@ -21,6 +21,9 @@
 /datum/fabricator_recipe/textiles/overwear/coathoodie
 	path = /obj/item/clothing/suit/storage/toggle/hoodie
 
+/datum/fabricator_recipe/textiles/overwear/wintercoat
+    path = /obj/item/clothing/suit/storage/hooded/wintercoat
+
 /datum/fabricator_recipe/textiles/overwear/hoodiealt
 	path = /obj/item/clothing/suit/storage/toggle/hoodie/black
 

--- a/code/modules/fabrication/designs/textile/overwear.dm
+++ b/code/modules/fabrication/designs/textile/overwear.dm
@@ -22,7 +22,7 @@
 	path = /obj/item/clothing/suit/storage/toggle/hoodie
 
 /datum/fabricator_recipe/textiles/overwear/wintercoat
-    path = /obj/item/clothing/suit/storage/hooded/wintercoat
+	path = /obj/item/clothing/suit/storage/hooded/wintercoat
 
 /datum/fabricator_recipe/textiles/overwear/hoodiealt
 	path = /obj/item/clothing/suit/storage/toggle/hoodie/black

--- a/code/modules/fabrication/designs/textile/storage.dm
+++ b/code/modules/fabrication/designs/textile/storage.dm
@@ -1,0 +1,3 @@
+/datum/fabricator_recipe/textiles/storage
+	category = "Storage"
+	path = /obj/item/storage/backpack

--- a/code/modules/fabrication/designs/textile/storage.dm
+++ b/code/modules/fabrication/designs/textile/storage.dm
@@ -1,3 +1,21 @@
 /datum/fabricator_recipe/textiles/storage
 	category = "Storage"
 	path = /obj/item/storage/backpack
+
+/datum/fabricator_recipe/textiles/storage/dufflebag
+    path = /obj/item/storage/backpack/dufflebag
+
+/datum/fabricator_recipe/textiles/storage/satchel
+    path = /obj/item/storage/backpack/satchel
+
+/datum/fabricator_recipe/textiles/storage/messenger
+   path = /obj/item/storage/backpack/messenger
+
+/datum/fabricator_recipe/textiles/storage/tool_belt
+    path= /obj/item/storage/belt/utility
+
+/datum/fabricator_recipe/textiles/storage/wallet
+    path = /obj/item/storage/wallet/leather
+
+/datum/fabricator_recipe/textiles/storage/money_bag
+    path = /obj/item/storage/bag/cash

--- a/code/modules/fabrication/designs/textile/storage.dm
+++ b/code/modules/fabrication/designs/textile/storage.dm
@@ -3,19 +3,19 @@
 	path = /obj/item/storage/backpack
 
 /datum/fabricator_recipe/textiles/storage/dufflebag
-    path = /obj/item/storage/backpack/dufflebag
+	path = /obj/item/storage/backpack/dufflebag
 
 /datum/fabricator_recipe/textiles/storage/satchel
-    path = /obj/item/storage/backpack/satchel
+	path = /obj/item/storage/backpack/satchel
 
 /datum/fabricator_recipe/textiles/storage/messenger
-   path = /obj/item/storage/backpack/messenger
+	path = /obj/item/storage/backpack/messenger
 
 /datum/fabricator_recipe/textiles/storage/tool_belt
-    path= /obj/item/storage/belt/utility
+	path= /obj/item/storage/belt/utility
 
 /datum/fabricator_recipe/textiles/storage/wallet
-    path = /obj/item/storage/wallet/leather
+	path = /obj/item/storage/wallet/leather
 
 /datum/fabricator_recipe/textiles/storage/money_bag
-    path = /obj/item/storage/bag/cash
+	path = /obj/item/storage/bag/cash

--- a/nebula.dme
+++ b/nebula.dme
@@ -1914,6 +1914,7 @@
 #include "code\modules\fabrication\designs\textile\overwear.dm"
 #include "code\modules\fabrication\designs\textile\protective.dm"
 #include "code\modules\fabrication\designs\textile\space.dm"
+#include "code\modules\fabrication\designs\textile\storage.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\TextFilters.dm"
 #include "code\modules\food\recipes_microwave.dm"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

Moved all of the clothing and storage items of the biogenerator to the textiles fabricator.
Added a new "Storage" category to the textiles fabricator that accomodates some of the removed items from the biogenerator that didn't "fit" with the rest of the textiles items (e.g: tool belt, wallet, backpack), also added some storage items that were previously uncraftable (dufflebag and messenger backpack).
Also gave chameleon kit a material price since it's a printable item on the autolathe and was causing issues because it couldn't be printed.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
