### PR TITLE
Fixes spawn skill point message - Fixes Issue #199

### DIFF
--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -31,7 +31,7 @@
 
 	user.add_language(/decl/language/human/common)
 	
-	to_chat(user, SPAN_NOTICE("You have an additional [STARTING_POINTS] skill points to apply to your character. Use the 'Adjust Skills' verb to do so"))
+	to_chat(user, SPAN_NOTICE("You have an additional [mob_set.points_remaining] skill points to apply to your character. Use the 'Adjust Skills' verb to do so"))
 
 	var/obj/starter_book = user.mind.role.text_book_type 
 	


### PR DESCRIPTION
Makes the spawn message take from actual points left to adjust, not STARTING_POINTS.
- Fixes #199