### PR TITLE
Changes the Cortical Chat prefix from',?' to ',h'

### DIFF
--- a/mods/persistence/modules/mob/language/cortical.dm
+++ b/mods/persistence/modules/mob/language/cortical.dm
@@ -1,7 +1,7 @@
 /decl/language/cortical
 	name = "Cortical Chat"
 	desc = "An algamation of recorded electrochemical signals and subvocalizations that can be transmitted via PLEXUS to all of those with cortical stacks."
-	key = "c"
+	key = "h"
 	colour = "interface"
 	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND | NO_TALK_MSG | NO_STUTTER
 	shorthand = "CC"

--- a/mods/persistence/modules/mob/language/cortical.dm
+++ b/mods/persistence/modules/mob/language/cortical.dm
@@ -1,7 +1,7 @@
 /decl/language/cortical
 	name = "Cortical Chat"
 	desc = "An algamation of recorded electrochemical signals and subvocalizations that can be transmitted via PLEXUS to all of those with cortical stacks."
-	key = "?"
+	key = "/"
 	colour = "interface"
 	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND | NO_TALK_MSG | NO_STUTTER
 	shorthand = "CC"

--- a/mods/persistence/modules/mob/language/cortical.dm
+++ b/mods/persistence/modules/mob/language/cortical.dm
@@ -1,7 +1,7 @@
 /decl/language/cortical
 	name = "Cortical Chat"
 	desc = "An algamation of recorded electrochemical signals and subvocalizations that can be transmitted via PLEXUS to all of those with cortical stacks."
-	key = "/"
+	key = "c"
 	colour = "interface"
 	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND | NO_TALK_MSG | NO_STUTTER
 	shorthand = "CC"


### PR DESCRIPTION
Changes the prefix needed to use Cortical Chat from ',?' to ',h'. This way, you don't need to press shift every time you send a message. Changed it to 'h' so people using non-American keyboards can also easily use cortical chat. Very minor QoL fix.

- Fixes #205 

## Changelog
:cl:
tweak: Changed the prefix for Cortical Chat from ',?' to ',h'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
