### PR TITLE
pain and saved vars for portable generators, radios, gas  heater/cooler

### DIFF
--- a/mods/persistence/saved_vars.json
+++ b/mods/persistence/saved_vars.json
@@ -1638,7 +1638,8 @@
 	{
 		"path":"/obj/machinery/power/port_gen",
 		"vars":[
-			"active"
+			"active",
+			"power_output"
 		]
 	},
 	{
@@ -2678,6 +2679,7 @@
 	{
 		"path":"/obj/item/stock_parts/radio",
 		"vars":[
+			"id_tag",
 			"frequency",
 			"filter",
 			"encryption",
@@ -4279,6 +4281,20 @@
 		"path":"/obj/machinery/destructive_analyzer",
 		"vars":[
 			"loaded_item"
+		]
+	},
+	{
+		"path":"/obj/machinery/atmospherics/unary/heater",
+		"vars":[
+			"set_temperature",
+			"power_setting"
+		]
+	},
+	{
+		"path":"/obj/machinery/atmospherics/unary/freezer",
+		"vars":[
+			"set_temperature",
+			"power_setting"
 		]
 	}
 ]


### PR DESCRIPTION
## Description of changes
* Added saved vars for radio transmitters since they didn't save their ID tag apparently.
* Added saved vars for generators not saving their power level.
* Added saved vars for gas cooler and heater not saving their state, power level, and target temperature.

Would add more, but its a pain in the ass to add many of those at once. Miss my old macros that did it really easily. 