### PR TITLE
Blacklisting Graffiti Capabilities For Sharp Tools

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -948,6 +948,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/update_clothing_icon()
 	return
 
-// Defaults to sharp items being able to engrave surfaces which can be over ridden via calling the proc and returning FALSE
+// Defaults to sharp items being able to engrave surfaces which can be prevented by overriding the proc and returning FALSE
 /obj/item/proc/can_engrave()
 	return sharp

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -947,3 +947,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/proc/update_clothing_icon()
 	return
+
+// Defaults to sharp items being able to engrave surfaces which can be over ridden via calling the proc and returning FALSE
+/obj/item/proc/can_engrave()
+	return sharp

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -51,3 +51,6 @@
 
 /obj/item/screwdriver/gold
 	material = /decl/material/solid/metal/gold
+
+/obj/item/screwdriver/can_engrave()
+	return FALSE

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -51,3 +51,7 @@
 		return
 	else
 		..()
+
+// Disables engraving for wirecutters because agony
+/obj/item/wirecutters/can_engrave()
+	return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -312,8 +312,7 @@ var/global/const/enterloopsanity = 100
 	return FALSE
 
 /turf/proc/try_graffiti(var/mob/vandal, var/obj/item/tool)
-
-	if(!tool.sharp || !can_engrave() || vandal.a_intent != I_HELP)
+	if(!tool.can_engrave() || !can_engrave() || vandal.a_intent != I_HELP)
 		return FALSE
 
 	if(jobban_isbanned(vandal, "Graffiti"))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: removed the ability for wirecutters and screwdrivers to write graffiti for QoL.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Adds the ability to prevent items that are sharp from etching graffiti onto turfs.
- Prevents Screwdriver from etching
- Prevents Wirecutters from etching
- Fixes #215 