### PR TITLE
Fix double click to see turf content happening always on dbl click

### DIFF
--- a/mods/persistence/_onclick/click.dm
+++ b/mods/persistence/_onclick/click.dm
@@ -5,7 +5,6 @@
 
 // Default behavior: ignore double clicks, the second click that makes the doubleclick call already calls for a normal click
 /mob/DblClickOn(var/atom/A, var/params)
-	. = A.show_atom_list_for_turf(src, get_turf(A))
 	if(SSautosave.saving)
 		return
 	. = ..()


### PR DESCRIPTION
* Removes the forced override to see turf contents each times someone double clicks regardless of preference settings.

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes
Finally the turf contents menu won't pop each times you're trying to fight and won't lag you out for seconds...

## Why and what will this PR improve

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: Fixed double clicking always opening the turf contents tab and lagging the clients out.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
