### PR TITLE
Increase mariadb timeout

### DIFF
--- a/sql/nebula.cnf
+++ b/sql/nebula.cnf
@@ -1,3 +1,3 @@
 [mysqld]
 max_allowed_packet=500M
-wait_timeout=360
+wait_timeout=36000

--- a/sql/nebula.cnf
+++ b/sql/nebula.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 max_allowed_packet=500M
+wait_timeout=360


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Increases the connection timeout on the MariaDB instance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve

Currently saves are failing, and the logs we have to go on indicate an idle connection timeout by the server. It's possible that the save is initiating a connection and failing to commit any data to the server before the default timeout is exceeded (`28800`).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

@Milkshak3s 

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
ops:
- Increasing mariadb timeout

/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
