### PR TITLE
Hopefully fixes saving after sql db connection gets reset

### DIFF
--- a/mods/persistence/_persistence.dm
+++ b/mods/persistence/_persistence.dm
@@ -6,6 +6,7 @@
 	admin_verbs_admin.Add(/client/proc/save_server)
 	admin_verbs_admin.Add(/client/proc/regenerate_mine)
 	admin_verbs_admin.Add(/client/proc/database_status)
+	admin_verbs_admin.Add(/client/proc/database_reconect)
 	admin_verbs_admin.Add(/client/proc/remove_character)
 	for(var/client/C in global.admins)
 		C.remove_admin_verbs()

--- a/mods/persistence/controllers/subsystems/mapping.dm
+++ b/mods/persistence/controllers/subsystems/mapping.dm
@@ -3,11 +3,14 @@
 
 /datum/controller/subsystem/mapping/Initialize(timeofday)
 	. = ..()
+#ifndef UNIT_TEST
+	var/save_exists = SSpersistence.SaveExists()
+#endif
 	// Load our maps dynamically.
 	for(var/z in global.using_map.default_levels)
 		var/map_file = global.using_map.default_levels[z]
 #ifndef UNIT_TEST
-		if(SSpersistence.SaveExists() && (text2num(z) in SSpersistence.saved_levels))
+		if(save_exists && (text2num(z) in SSpersistence.saved_levels))
 			// Load a default map instead.
 			INCREMENT_WORLD_Z_SIZE
 			continue

--- a/mods/persistence/modules/admin/verbs/admin.dm
+++ b/mods/persistence/modules/admin/verbs/admin.dm
@@ -40,3 +40,12 @@
 	if(!check_rights(R_ADMIN))
 		return
 	SSpersistence.print_db_status()
+
+/client/proc/database_reconect()
+	set category = "Server"
+	set desc = "Force reconnect to the SQL save DB."
+	set name = "Database Force Reconnect"
+
+	if(!check_rights(R_ADMIN))
+		return
+	SQLS_Force_Reconnect()

--- a/mods/persistence/modules/mob/new_player.dm
+++ b/mods/persistence/modules/mob/new_player.dm
@@ -100,8 +100,7 @@
 			return
 	// Query for the character associated with this ckey
 	var/DBQuery/char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata` = '[ckey]'")
-	char_query.Execute()
-	if(char_query.ErrorMsg())
+	if(!char_query.Execute())
 		to_world_log("CHARACTER DESERIALIZATION FAILED: [char_query.ErrorMsg()].")
 	if(char_query.NextRow())
 		var/list/char_items = char_query.GetRowData()

--- a/mods/persistence/modules/world_save/_defines/_serializer.dm
+++ b/mods/persistence/modules/world_save/_defines/_serializer.dm
@@ -25,17 +25,16 @@
 #define SQLS_TABLE_LIMBO_DATUM_VARS 	"limbo_thing_var"
 #define SQLS_TABLE_LIMBO_LIST_ELEM		"limbo_list_element"
 
-var/global/_sqls_cached_error
 #define SQLS_EXECUTE_ROWCHANGE_AND_REPORT_ERROR(QUERY, ERRORMSG)\
-	QUERY.Execute();\
-	_sqls_cached_error = QUERY.ErrorMsg();\
-	if(!QUERY.RowsAffected() || _sqls_cached_error){\
-		to_world_log(ERRORMSG + " '[_sqls_cached_error]'");\
+	if(!QUERY.Execute() || !QUERY.RowsAffected()){\
+		var/errormsg = ERRORMSG + " '[QUERY.ErrorMsg()]'"; \
+		to_world_log(errormsg);\
+		throw new /exception/sql_connection(errormsg, __FILE__, __LINE__); \
 	}
 
 #define SQLS_EXECUTE_AND_REPORT_ERROR(QUERY, ERRORMSG)\
-	QUERY.Execute();\
-	_sqls_cached_error = QUERY.ErrorMsg();\
-	if(_sqls_cached_error){\
-		to_world_log(ERRORMSG + " '[_sqls_cached_error]'");\
+	if(!QUERY.Execute()){\
+		var/errormsg = ERRORMSG + " '[QUERY.ErrorMsg()]'"; \
+		to_world_log(errormsg);\
+		throw new /exception/sql_connection(errormsg, __FILE__, __LINE__); \
 	}

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -1,29 +1,34 @@
+/proc/SQLS_Force_Reconnect()
+	setup_save_database_connection()
+	to_chat(usr, "Forced db connection to be reconnected!")
+	if(!check_save_db_connection())
+		to_chat(usr, SPAN_WARNING("Reconnect failed.."))
+	else
+		to_chat(usr, "Reconnect successful")
+	to_chat(usr, "Running test query SELECT DATABASE();")
+
+	var/DBQuery/dbq = global.dbcon_save.NewQuery("SELECT DATABASE();")
+	if(dbq.Execute() && dbq.NextRow())
+		to_chat(usr, "Test query returned: '[dbq.item[1]]'!") 
+	else 
+		to_chat(usr, SPAN_WARNING("Failed with error: '[dbcon_save.ErrorMsg()]'"))
+
 /proc/SQLS_Print_DB_STATUS()
 	if(!establish_save_db_connection())
-		CRASH("Couldn't get DB status, connection failed!")
+		to_chat(usr, "Couldn't get DB status, connection failed: [dbcon_save.ErrorMsg()]")
+		return
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT `id`, `z`, `dynamic`, `default_turf` FROM `[SQLS_TABLE_Z_LEVELS]`")
-	query.Execute()
-
-	if(query.ErrorMsg())
+	var/DBQuery/query = dbcon_save.NewQuery("SELECT `id`, `z`, `dynamic`, `default_turf` FROM `[SQLS_TABLE_Z_LEVELS]`")
+	if(!query.Execute())
 		to_chat(usr, "Error: [query.ErrorMsg()]")
-
 	if(!query.RowCount())
 		to_chat(usr, "No Z data...")
 
 	while(query.NextRow())
 		to_chat(usr, "Z data: (ID: [query.item[1]], Z: [query.item[2]], Dynamic: [query.item[3]], Default Turf: [query.item[4]])")
 
-	query = dbcon.NewQuery("ANALYZE TABLE `list`, `[SQLS_TABLE_LIST_ELEM]`, `[SQLS_TABLE_DATUM]`, `[SQLS_TABLE_DATUM_VARS]`;")
-	query.Execute()
-	
-	if(query.ErrorMsg())
-		to_chat(usr, "Error: [query.ErrorMsg()]")
-
-	query = dbcon.NewQuery("SELECT `TABLE_NAME`, `TABLE_ROWS` FROM information_schema.tables WHERE `TABLE_NAME` IN ('[SQLS_TABLE_LIST_ELEM]', '[SQLS_TABLE_DATUM]', '[SQLS_TABLE_DATUM_VARS]')")
-	query.Execute()
-
-	if(query.ErrorMsg())
+	query = dbcon_save.NewQuery("SELECT `TABLE_NAME`, `TABLE_ROWS` FROM information_schema.tables WHERE `TABLE_NAME` IN ('[SQLS_TABLE_LIST_ELEM]', '[SQLS_TABLE_DATUM]', '[SQLS_TABLE_DATUM_VARS]')")
+	if(!query.Execute())
 		to_chat(usr, "Error: [query.ErrorMsg()]")
 		return
 
@@ -486,10 +491,11 @@
 		CRASH("SQL Serializer: Failed to connect to db!")
 
 	var/DBQuery/query
+	var/exception/last_except
 	try
 		if(length(thing_inserts) > 0)
 			query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_DATUM]`(`p_id`,`type`,`x`,`y`,`z`,`ref`) VALUES[jointext(thing_inserts, ",")] ON DUPLICATE KEY UPDATE `p_id` = `p_id`")
-			SQLS_EXECUTE_ROWCHANGE_AND_REPORT_ERROR(query, "THING SERIALIZATION FAILED:")
+			SQLS_EXECUTE_AND_REPORT_ERROR(query, "THING SERIALIZATION FAILED:")
 		if(length(var_inserts) > 0)
 			query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_DATUM_VARS]`(`thing_id`,`key`,`type`,`value`) VALUES[jointext(var_inserts, ",")]")
 			SQLS_EXECUTE_ROWCHANGE_AND_REPORT_ERROR(query, "VAR SERIALIZATION FAILED:")
@@ -498,13 +504,20 @@
 			query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIST_ELEM]`(`list_id`,`key`,`key_type`,`value`,`value_type`) VALUES[jointext(element_inserts, ",")]")
 			SQLS_EXECUTE_ROWCHANGE_AND_REPORT_ERROR(query, "ELEMENT SERIALIZATION FAILED:")
 	catch (var/exception/e)
-		to_world_log("World Serializer Failed")
-		to_world_log(e)
+		if(istype(e, /exception/sql_connection))
+			last_except = e //Throw it after we clean up
+		else
+			to_world_log("World Serializer Failed")
+			to_world_log(e)
 
 	thing_inserts.Cut(1)
 	var_inserts.Cut(1)
 	element_inserts.Cut(1)
 	inserts_since_commit = 0
+
+	//Throw after we cleanup
+	if(last_except)
+		throw last_except
 
 /serializer/sql/proc/CommitRefUpdates()
 	if(!establish_save_db_connection())
@@ -522,7 +535,7 @@
 		case_list.Add("WHEN `p_id` = '[p_id]' THEN '[new_ref]'")
 	if(length(where_list) && length(case_list))
 		query = dbcon_save.NewQuery("UPDATE `[SQLS_TABLE_DATUM]` SET `ref` = CASE [jointext(case_list, " ")] END WHERE `p_id` IN ([jointext(where_list, ", ")])")
-		SQLS_EXECUTE_ROWCHANGE_AND_REPORT_ERROR(query, "REFERENCE UPDATE FAILED:")
+		SQLS_EXECUTE_AND_REPORT_ERROR(query, "REFERENCE UPDATE FAILED:")
 
 	ref_updates.Cut()
 	inserts_since_ref_update = 0

--- a/mods/persistence/modules/world_save/serializers/sql_serializer_db.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer_db.dm
@@ -1,15 +1,27 @@
 /*
 	A separate db connection for saving that is more thoroughly checked than the default connection.
 */
+//Exception type for sql connection errors specifically
+/exception/sql_connection
+
 var/global/DBConnection/dbcon_save
 
 /proc/establish_save_db_connection()
-	if(!global.dbcon_save || !global.dbcon_save.IsConnected())
+	if(!check_save_db_connection())
 		return setup_save_database_connection()
-	return global.dbcon_save.IsConnected()
+	return check_save_db_connection()
 
 /proc/check_save_db_connection()
 	return global.dbcon_save && global.dbcon_save.IsConnected()
+	// if(!global.dbcon_save || !global.dbcon_save.IsConnected())
+	// 	return FALSE
+	// var/DBQuery/dbq = global.dbcon_save.NewQuery("SELECT DATABASE();")
+	// . = dbq.Execute()
+	// if(!.)
+	// 	to_world_log("check_save_db_connection: failed after execution : '[dbq.ErrorMsg()]'")
+	// 	return FALSE
+	// if(dbq.NextRow())
+	// 	to_world_log("check_save_db_connection: Test query returned '[dbq.item[1]]'")
 
 /proc/close_save_db_connection()
 	if(global.dbcon_save && global.dbcon_save.IsConnected())
@@ -17,11 +29,11 @@ var/global/DBConnection/dbcon_save
 	return !global.dbcon_save || !global.dbcon_save.IsConnected()
 
 /proc/setup_save_database_connection()
-	if(!global.dbcon_save)
-		global.dbcon_save = new()
-
+	if(global.dbcon_save)
+		QDEL_NULL(global.dbcon_save)
+	global.dbcon_save = new()
 	global.dbcon_save.Connect("dbi:mysql:[sqldb]:[sqladdress]:[sqlport]","[sqllogin]","[sqlpass]")
-	. = global.dbcon_save.IsConnected()
+	. = check_save_db_connection()
 	if(.)
 		// Setting encoding and comparison (4-byte UTF-8) for the DB server ~bear1ake
 		var/DBQuery/unicode_query = global.dbcon_save.NewQuery("SET NAMES utf8mb4 COLLATE utf8mb4_general_ci")


### PR DESCRIPTION
* Added reconnect verb to force a reconnect to the db just in case.
* Changed all instances of checking errors with the ErrorMsg() proc to something that works. Since ErrorMsg() doesn't clear between queries/connections.
* SQL connection errors now go through the try-catches in the saving/loading code as they should.
* Sincee it seems like RowsAffected doesn't counts UPDATE command as affecting rows changed some of the checks for some queries done during saving to prevent save crashes.
