### PR TITLE
Allows maps to define specific areas to save by default

### DIFF
--- a/mods/persistence/_maps.dm
+++ b/mods/persistence/_maps.dm
@@ -1,2 +1,3 @@
 /datum/map
 	var/list/saved_levels = list()   // Z-levels that will be persisted to a database layer during saving intervals. 
+	var/list/saved_areas = list() // Areas that will be persisted to the database during saving intervals

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -23,6 +23,7 @@
 
 /datum/controller/subsystem/persistence/Initialize()
 	saved_levels = global.using_map.saved_levels
+	saved_areas = global.using_map.saved_areas
 
 /datum/controller/subsystem/persistence/proc/SaveExists()
 	if(!save_exists)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Adds a table to maps that allows you to define areas to be saved/loaded persistently.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
This will be useful for defining areas outside of saving Z-levels for persistence. F.ex. the area immediately around the ladders on mining Z-levels, a set of buried ruins, the interior of a space station, or anything else that you'd want to be persistent in an otherwise non-saving Z-level.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak: Added saved_areas var to maps
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
