### PR TITLE
Feb Kleibkhar fixes

### DIFF
--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -60,6 +60,7 @@
 #include "game\turfs\simulated\walls.dm"
 #include "game\turfs\simulated\wall_attacks.dm"
 #include "game\turfs\turf.dm"
+#include "game\turfs\exterior\_exterior.dm"
 #include "game\turfs\exterior\exterior_wall.dm"
 #include "game\turfs\flooring\flooring.dm"
 #include "game\turfs\flooring\flooring_premade.dm"

--- a/mods/persistence/controllers/subsystems/mining.dm
+++ b/mods/persistence/controllers/subsystems/mining.dm
@@ -1,3 +1,5 @@
+/turf/exterior/barren/mining
+
 /datum/random_map/automata/cave_system/outreach
 	floor_type = /turf/exterior/barren/mining
 	var/rich_mineral_turf = /turf/exterior/wall/random/high_chance
@@ -36,14 +38,6 @@
 		num_applied += 1
 		T.ChangeTurf(new_path, minerals)
 		get_additional_spawns(map[tmp_cell], T)
-
-// Mining turfs may have issues finding an owner on load - upon return air, look for the owner if one does not exist
-/turf/exterior/barren/mining/return_air()
-	if(!owner)
-		owner = LAZYACCESS(global.overmap_sectors, "[z]")
-		if(!istype(owner))
-			owner = null
-	. = ..()
 
 SUBSYSTEM_DEF(mining)
 	name = "Mining"

--- a/mods/persistence/game/turfs/exterior/_exterior.dm
+++ b/mods/persistence/game/turfs/exterior/_exterior.dm
@@ -1,0 +1,13 @@
+// Multi-z planets create inconsistencies in when planets exist for the owner of exterior turfs to be set. If an owner can't be found,
+// we ask turfs to check again later.
+/turf/exterior/Initialize(mapload, no_update_icon)
+	. = ..()
+	if(!owner)
+		return INITIALIZE_HINT_LATELOAD
+
+/turf/exterior/LateInitialize()
+	. = ..()
+	if(!owner)
+		owner = LAZYACCESS(global.overmap_sectors, "[z]")
+		if(!istype(owner))
+			owner = null

--- a/mods/persistence/modules/overmap/ships/landable.dm
+++ b/mods/persistence/modules/overmap/ships/landable.dm
@@ -11,7 +11,8 @@
 /obj/effect/overmap/visitable/ship/landable/Initialize()
 	if(!SSshuttle.shuttles[shuttle] && persistent_id)
 		if(saved_landmark && saved_areas)
-			new /datum/shuttle/autodock/overmap/created(null, saved_landmark, saved_areas.Copy(), shuttle)
+			var/list/shuttle_args = list(saved_landmark, saved_areas.Copy(), shuttle)
+			SSshuttle.initialize_shuttle(/datum/shuttle/autodock/overmap/created, null, shuttle_args)
 		else
 			log_warning("Landable ship could not rebuild shuttle!")
 	saved_landmark = null


### PR DESCRIPTION
## Description of changes
A couple minor fixes before open testing, independent of our larger refactors
* Makes exterior turfs attempt to locate their owner again on LateInitialize if they fail to locate it the first time. This fixes the bug where the upper level of Kleibkhar would not have an atmosphere.
* Landable ships now rebuild their shuttle using the SSshuttle.initialize_shuttle() proc. This fixes a bug where terminals would be ripped out on shuttle movement after load, and should keep things more consistent in general.
## Why and what will this PR improve

Bug fix good.

## Authorship

Myself. Thanks to PsyCommando for bringing the terminal bug back to my attention.
