### PR TITLE
Add Character Selection/Deletion, Protect against Duplicates

### DIFF
--- a/mods/persistence/controllers/subsystems/initialization/chargen.dm
+++ b/mods/persistence/controllers/subsystems/initialization/chargen.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(chargen)
 		var/chargen_pod_counter = 1
 		for(var/x in 1 to FLOOR(world.maxx / width))
 			for(var/y in 1 to FLOOR(world.maxy / height))
-				// We already loaded the first one at (1, 1) so skip it 
+				// We already loaded the first one at (1, 1) so skip it
 				if(x == 1 && y == 1)
 					continue
 				if(chargen_pod_counter >= MAX_NB_CHAR_GEN_PODS)
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(chargen)
 	if(!pod.chargen_landmark)
 		log_warning("Chargen pod '[pod]' has not landmark set!")
 		return
-	
+
 	//Because spawnpoints don't have a proc to return turfs and instead just share their turf var to grab the available turfs, we gotta change the spawnpoint :D
 	var/decl/spawnpoint/chargen/C = GET_DECL(/decl/spawnpoint/chargen)
 	if(C)
@@ -101,11 +101,11 @@ SUBSYSTEM_DEF(chargen)
 	var/area/chargen/A = get_area(myturf)
 	if(istype(A))
 		SSchargen.assign_spawn_pod(A) //Mark the pod area as reserved
-	else 
+	else
 		var/mess = "'[victim]' (CKEY: [victim.ckey]) spawned outside chargen for some reasons."
 		log_warning(mess)
 		message_staff(mess)
-	SSpersistence.AddToLimbo(victim.mind, victim.mind.unique_id, LIMBO_MIND, victim.mind.key, TRUE)
+	SSpersistence.AddToLimbo(victim.mind, victim.mind.unique_id, LIMBO_MIND, victim.mind.key, victim.mind.current.real_name, TRUE)
 
 /datum/job/colonist/get_roundstart_spawnpoint()
 	CRASH("!!!!! datum/job/colonist/get_roundstart_spawnpoint() was called! !!!!!")

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -14,7 +14,7 @@
 
 	var/serializer/sql/serializer = new() // The serializer impl for actually saving.
 	var/serializer/sql/one_off/one_off	= new() // The serializer impl for one off serialization/deserialization.
-	
+
 	var/list/limbo_removals = list() // Objects which will be removed from limbo on the next save. Format is list(limbo_key, limbo_type)
 
 	var/loading_world = FALSE
@@ -37,7 +37,7 @@
 	serializer._before_serialize()
 
 	var/start = world.timeofday
-	
+
 	// Launch events
 
 	events_repository.raise_event(/decl/observ/world_saving_start_event, src)
@@ -75,7 +75,7 @@
 			zone.c_invalidate()
 		report_progress("Invalidated in [(REALTIMEOFDAY - time_start_airzones) / (1 SECOND)]s")
 		sleep(5)
-		
+
 		report_progress("Removing queued limbo objects..")
 		sleep(5)
 
@@ -100,7 +100,7 @@
 			// Check to see if the mobs are already being saved.
 			if(!QDELETED(current_mob) && ((current_mob.z in SSpersistence.saved_levels) || (get_area(current_mob) in SSpersistence.saved_areas)))
 				continue
-			one_off.AddToLimbo(char_mind, char_mind.unique_id, LIMBO_MIND, char_mind.persistent_id, char_mind.key, FALSE)
+			one_off.AddToLimbo(char_mind, char_mind.unique_id, LIMBO_MIND, char_mind.persistent_id, char_mind.key, char_mind.current.real_name, FALSE)
 		report_progress("Done adding player minds to limbo in [(REALTIMEOFDAY - time_start_limbo_minds) / (1 SECOND)]s.")
 		sleep(5)
 
@@ -165,7 +165,7 @@
 			var/datum/persistence/load_cache/z_level/z_level = z_transform[z]
 			serializer.z_map["[z_level.index]"] = z_level.new_index
 		serializer.z_index = new_z_index
-		
+
 		// Now we find all the area datums themselves that need to be saved, since keeping references on the turfs is a huge waste of space.
 		var/list/areas_to_serialize = list()
 		for(var/area/A in global.areas)
@@ -413,7 +413,7 @@
 		new_db_connection = TRUE
 	for(var/datum/wrapper/late/L AS_ANYTHING in late_wrappers)
 		L.on_late_load()
-	
+
 	late_wrappers.Cut()
 	if(new_db_connection)
 		close_save_db_connection()
@@ -453,13 +453,13 @@
 	to_chat(user, SPAN_INFO("Disabled with persistence modpack (how ironic)..."))
 	return
 
-/datum/controller/subsystem/persistence/proc/AddToLimbo(var/datum/thing, var/key, var/limbo_type, var/metadata, var/modify = TRUE)
+/datum/controller/subsystem/persistence/proc/AddToLimbo(var/datum/thing, var/key, var/limbo_type, var/metadata, var/metadata2, var/modify = TRUE)
 	var/new_db_connection = FALSE
 	if(!check_save_db_connection())
 		if(!establish_save_db_connection())
 			CRASH("SSPersistence: Couldn't establish DB connection during Limbo Addition!")
 		new_db_connection = TRUE
-	. = one_off.AddToLimbo(thing, key, limbo_type, metadata, modify)
+	. = one_off.AddToLimbo(thing, key, limbo_type, metadata, metadata2, modify)
 	if(new_db_connection)
 		close_save_db_connection()
 
@@ -502,7 +502,7 @@
 		if(existing && !QDELETED(existing) && existing.persistent_id == items["p_id"])
 			. = existing
 		break
-	
+
 	if(new_db_connection)
 		close_save_db_connection()
 

--- a/mods/persistence/game/machinery/cryopod.dm
+++ b/mods/persistence/game/machinery/cryopod.dm
@@ -5,7 +5,7 @@
 
 /obj/machinery/cryopod/Initialize()
 	old_intercom = locate() in src
-	
+
 	// While we could save the occupant var directly, this is much less likely to cause issues with floating mob references.
 	var/mob/living/carbon/human/old_occupant = locate() in src
 	if(old_occupant)
@@ -97,10 +97,10 @@
 			C.SetStasis(2)
 
 		var/time_elapsed = world.time - time_entered
-		var/time_left = round((time_till_despawn - time_elapsed) / (1 SECOND)) 
+		var/time_left = round((time_till_despawn - time_elapsed) / (1 SECOND))
 		if((time_left > 0) && ((time_left % 5) == 0))
 			to_chat(occupant, SPAN_NOTICE("[time_left] seconds left until transfer to deep storage.."))
-		
+
 		//Force despawn when no client
 		if ((time_elapsed < time_till_despawn) && occupant.ckey)
 			return
@@ -125,7 +125,7 @@
 		H.home_spawn = src
 		var/datum/mind/occupant_mind = occupant.mind
 		if(occupant_mind)
-			SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, TRUE)
+			SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
 			QDEL_NULL(occupant.mind)
 		else
 			return

--- a/mods/persistence/modules/client/preferences.dm
+++ b/mods/persistence/modules/client/preferences.dm
@@ -61,6 +61,9 @@
 		if(!real_name)
 			to_chat(usr, "<span class='danger'>The must set a unique character name to continue.</span>")
 			return
+		switch(alert("Are you sure you want to finalize your character and join the game with the character you've created?", "Character Confirmation", "Yes", "No"))
+			if("No")
+				return
 		var/DBQuery/char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata2` = '[real_name]'")
 		if(!char_query.Execute())
 			to_world_log("DUPLICATE NAME CHECK DESERIALIZATION FAILED: [char_query.ErrorMsg()].")
@@ -86,9 +89,7 @@
 
 		save_preferences()
 		save_character()
-		switch(alert("Are you sure you want to finalize your character and join the game with the character you've created?", "Character Confirmation", "Yes", "No"))
-			if("No")
-				return
+		
 		if(isnewplayer(client.mob))
 			close_char_dialog(usr)
 			var/mob/new_player/M = client.mob

--- a/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
@@ -122,7 +122,7 @@
 		LAZYADD(resolver.lists["[items["list_id"]]"], element)
 		resolver.lists_cached++
 
-/serializer/sql/one_off/proc/AddToLimbo(var/list/things, var/key, var/limbo_type, var/metadata, var/modify = TRUE)
+/serializer/sql/one_off/proc/AddToLimbo(var/list/things, var/key, var/limbo_type, var/metadata, var/metadata2, var/modify = TRUE)
 
 	// Check to see if this thing was already placed into limbo. If so, we go ahead and remove the thing from limbo first before reserializing.
 	// When this occurs, it's possible things will be dropped from the database. Avoid serializing things into limbo which will remain in the game world.
@@ -130,6 +130,7 @@
 	key = sanitize_sql(key)
 	limbo_type = sanitize_sql(limbo_type)
 	metadata = sanitize_sql(metadata)
+	metadata2 = sanitize_sql(metadata2)
 
 	// The 'limbo_assoc' column in the database relates every thing, thing_var, and list_element to an instance of limbo insertion.
 	// While it uses the same PERSISTENT_ID format, it's not related to any datum's PERSISTENT_ID.
@@ -167,7 +168,7 @@
 	var/encoded_p_ids = json_encode(thing_p_ids)
 	// Insert into the limbo table, a metadata holder that allows for access to the limbo_assoc key by 'type' and 'key'.
 	var/DBQuery/insert_query
-	insert_query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIMBO]` (`key`,`type`,`p_ids`,`metadata`,`limbo_assoc`) VALUES('[key]', '[limbo_type]', '[encoded_p_ids]', '[metadata]', '[limbo_assoc]')")
+	insert_query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIMBO]` (`key`,`type`,`p_ids`,`metadata`,`limbo_assoc`, `metadata2`) VALUES('[key]', '[limbo_type]', '[encoded_p_ids]', '[metadata]', '[limbo_assoc]', '[metadata2]')")
 	SQLS_EXECUTE_AND_REPORT_ERROR(insert_query, "LIMBO ADDITION FAILED:")
 
 	Clear()

--- a/sql/V100__Persistence.sql
+++ b/sql/V100__Persistence.sql
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS `limbo` (
   `type` varchar(64) NOT NULL,
   `p_ids` longtext NOT NULL,
   `metadata` varchar(64) DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL
+  `limbo_assoc` varchar(12) NOT NULL,
+  `metadata2` varchar(64) DEFAULT NULL,
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
 
 DROP TABLE IF EXISTS `limbo_list_element`;


### PR DESCRIPTION
Adds a character selection screen capable of loading and deleting. Defaults regular players to two slots, but admins/developers get four.

Adds a metadata2 table to the limbo sql table, perfect for key pairings like real_name and ckey. When shuttles and other things are capable of being deserialized, I am confident they will use metadata 2.

The limbo table should be emptied and updated on all environments in order to ensure compatibility.
