### PR TITLE
Make chargen pod light up and open when traits picked

### DIFF
--- a/mods/persistence/modules/chargen/dossier_console.dm
+++ b/mods/persistence/modules/chargen/dossier_console.dm
@@ -59,6 +59,10 @@
 				to_chat(user, SPAN_NOTICE("The console beeps: Application incomplete. Please enter a role to proceed."))
 				return
 			user.mind.finished_chargen = TRUE
+			var/area/A = get_area(src)
+			var/obj/machinery/cryopod/chargen/pod = locate() in A
+			if(pod)
+				pod.ready_for_mingebag()
 		if("unsubmit")
 			user.mind.finished_chargen = FALSE
 		if("confirm_origin")

--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -8,6 +8,20 @@
 	global.latejoin_locations |= get_turf(src)
 	global.latejoin_cryo_locations |= get_turf(src)
 
+/obj/machinery/cryopod/chargen/Initialize()
+	. = ..()
+	icon_state = occupied_icon_state //Those starts closed
+
+/obj/machinery/cryopod/chargen/proc/ready_for_mingebag()
+	set_light(10, 1, COLOR_CYAN_BLUE)
+	icon_state = base_icon_state
+	if(open_sound)
+		playsound(src, open_sound, 40)
+
+/obj/machinery/cryopod/chargen/proc/unready()
+	icon_state = occupied_icon_state
+	set_light(0, null)
+
 // Chargen pod
 /obj/machinery/cryopod/chargen/proc/send_to_outpost()
 	if(!istype(occupant))
@@ -48,6 +62,7 @@
 			break
 
 	//Free up the chargen pod
+	unready()
 	SSchargen.release_spawn_pod(get_area(src))
 
 	for(var/turf/T in global.latejoin_cryo_locations)


### PR DESCRIPTION
## Description of changes
Make chargen pod light up and open when traits picked. Just to try to communicate a bit better that the pod is where they should go.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Made character generator pods light up when completing the character's background on the console.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
