### PR TITLE
Fixes migration schema for limbo metadata

### DIFF
--- a/sql/migrate/V100__Persistence.sql
+++ b/sql/migrate/V100__Persistence.sql
@@ -53,7 +53,8 @@ CREATE TABLE IF NOT EXISTS `limbo` (
   `type` varchar(64) NOT NULL,
   `p_ids` longtext NOT NULL,
   `metadata` varchar(64) DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL
+  `limbo_assoc` varchar(12) NOT NULL,
+  `metadata2` varchar(64) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
 
 CREATE TABLE IF NOT EXISTS `limbo_list_element` (


### PR DESCRIPTION
The migration schema must be updated at the same time as the normal SQL file.