### PR TITLE
Adds 2 New Infini-Vendors Redux

### DIFF
--- a/mods/persistence/modules/chargen/storage/industrial_boxes.dm
+++ b/mods/persistence/modules/chargen/storage/industrial_boxes.dm
@@ -111,3 +111,16 @@
 		/obj/item/stock_parts/capacitor = 1,
 		/obj/item/stock_parts/power/apc/buildable = 1,
 	)
+	
+/obj/item/chargen_box/ration/twinkies
+	name = "emergency twinkie kit"
+	icon_state = "donk_kit"
+	startswith = list(
+		/obj/item/chems/food/spacetwinkie = 8
+	)
+
+/obj/item/chargen_box/ration/mre
+	name = "MRE shipment"
+	startswith = list(
+		/obj/item/storage/mre/random = 5
+	)

--- a/mods/persistence/modules/chargen/vending/botany.dm
+++ b/mods/persistence/modules/chargen/vending/botany.dm
@@ -13,3 +13,43 @@
 		/obj/item/chargen_box/botany/hydroponics = 999
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
+	
+/obj/machinery/vending/infini/food
+	name = "Brownstone Solutions Snack-o-Matic"
+	desc = "A groundbreaking innovation in bluespace technology. Synthesizes and teleports packaged food from the nearest Brownstone Solutions facility to this vendor for you to enjoy."
+	markup = 0
+	icon_state = "nutri"
+	icon_vend = "nutri-vend"
+	vend_delay = 26
+	base_type = /obj/machinery/vending/infini/food
+	products = list(
+		/obj/item/chargen_box/ration/twinkies = 999,
+		/obj/item/chargen_box/ration/mre = 999,
+		/obj/item/chems/food/can/beef = 999,
+		/obj/item/chems/food/can/beans = 999,
+		/obj/item/chems/food/can/tomato = 999,
+		/obj/item/chems/food/sosjerky = 999,
+		/obj/item/chems/food/no_raisin = 999,
+		/obj/item/chems/food/cheesiehonkers = 999,
+		/obj/item/chems/food/syndicake = 999,
+		/obj/item/chems/food/pistachios = 999,
+		/obj/item/chems/food/lunacake = 999,
+		/obj/item/chems/food/lunacake/mochicake = 999,
+		/obj/item/chems/food/lunacake/mooncake = 999,
+		/obj/item/chems/food/triton = 999,
+		/obj/item/chems/food/saturn = 999,
+		/obj/item/chems/food/pluto = 999,
+		/obj/item/chems/food/venus = 999,
+		/obj/item/chems/food/chips = 999,
+		/obj/item/chems/food/candy = 999,
+		/obj/item/chems/food/tastybread = 999,
+		/obj/item/chems/food/liquidfood = 999,
+		/obj/item/chems/drinks/cans/waterbottle = 999,
+		/obj/item/chems/drinks/cans/iced_tea = 999,
+		/obj/item/chems/drinks/cans/grape_juice = 999,
+		/obj/item/chems/drinks/cans/cola = 999,
+		/obj/item/chems/drinks/cans/space_up = 999,
+		/obj/item/chems/drinks/cans/dr_gibb = 999,
+		/obj/item/chems/drinks/cans/speer = 999,
+		/obj/item/chems/drinks/cans/ale = 999
+	)

--- a/mods/persistence/modules/chargen/vending/botany.dm
+++ b/mods/persistence/modules/chargen/vending/botany.dm
@@ -16,7 +16,7 @@
 	
 /obj/machinery/vending/infini/food
 	name = "Brownstone Solutions Snack-o-Matic"
-	desc = "A groundbreaking innovation in bluespace technology. Synthesizes and teleports packaged food from the nearest Brownstone Solutions facility to this vendor for you to enjoy."
+	desc = "Advanced packaged food synthesizer. Uses electricity and hyper-technology to create food almost instantly. Brought to you by Brownstone Solutions, Inc."
 	markup = 0
 	icon_state = "nutri"
 	icon_vend = "nutri-vend"

--- a/mods/persistence/modules/chargen/vending/industrial.dm
+++ b/mods/persistence/modules/chargen/vending/industrial.dm
@@ -1,7 +1,7 @@
 
 /obj/machinery/vending/infini/industrial
-	name = "YouTool"
-	desc = "Tools for tools."
+	name = "Brownstone Solutions Toolfab Deluxe"
+	desc = "An engineering vendor that synthesizes both basic engineering equipment and materials for use in building."
 	markup = 0
 	icon_state = "tool"
 	icon_deny = "tool-deny"
@@ -19,6 +19,26 @@
 		/obj/item/chargen_box/industrial/autolathe = 999,
 		/obj/item/chargen_box/industrial/mining = 999,
 		/obj/item/chargen_box/industrial/chem_suit = 999,
+		/obj/item/chargen_box/industrial/pick = 999,
+		/obj/item/chargen_box/industrial/ore_processor = 999,
+		/obj/item/chargen_box/industrial/stirling = 999
+	)
+
+/obj/machinery/vending/infini/industrial/basic
+	name = "Brownstone Solutions Toolfab Standard"
+	desc = "An engineering vendor that synthesizes basic engineering equipment. Unfortunately, this one lacks the correct modules to print building materials."
+	markup = 0
+	icon_state = "tool"
+	icon_deny = "tool-deny"
+	icon_vend = "tool-vend"
+	vend_delay = 11
+	base_type = /obj/machinery/vending/infini/industrial/basic
+	products = list(
+		/obj/item/chargen_box/industrial/engineering = 999,
+		/obj/item/chargen_box/industrial/firefighter = 999,
+		/obj/item/chargen_box/industrial/building = 999,
+		/obj/item/chargen_box/industrial/autolathe = 999,
+		/obj/item/chargen_box/industrial/mining = 999,
 		/obj/item/chargen_box/industrial/pick = 999,
 		/obj/item/chargen_box/industrial/ore_processor = 999,
 		/obj/item/chargen_box/industrial/stirling = 999


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixed version of #303 .

Removed the Sustenance vendor icon. The foodvend now just uses the same icon as the Nutrivendor.
Brownstone Solutions has been accepted as a real thing that exists by Lore nerds. Not that it really matters, but just saying that to avoid that holding up the PR.

## Why and what will this PR improve

See reasoning on #303 , as this is the exact same thing but functional.

## Authorship
<!-- Describe original authors of changes to credit them. -->

Credit to genessee for code.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
rscadd: Food infini-vendor which can be spawned by admins
rscadd: Basic version of the engineering infini-vendor which lacks material spawns
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
