### PR TITLE
Assorted limbo adjustments

### DIFF
--- a/mods/persistence/controllers/subsystems/initialization/chargen.dm
+++ b/mods/persistence/controllers/subsystems/initialization/chargen.dm
@@ -105,7 +105,6 @@ SUBSYSTEM_DEF(chargen)
 		var/mess = "'[victim]' (CKEY: [victim.ckey]) spawned outside chargen for some reasons."
 		log_warning(mess)
 		message_staff(mess)
-	SSpersistence.AddToLimbo(victim.mind, victim.mind.unique_id, LIMBO_MIND, victim.mind.key, victim.mind.current.real_name, TRUE)
 
 /datum/job/colonist/get_roundstart_spawnpoint()
 	CRASH("!!!!! datum/job/colonist/get_roundstart_spawnpoint() was called! !!!!!")

--- a/mods/persistence/game/machinery/cryopod.dm
+++ b/mods/persistence/game/machinery/cryopod.dm
@@ -2,6 +2,7 @@
 
 /obj/machinery/cryopod
 	var/obj/item/radio/intercom/old_intercom
+	var/despawning = FALSE
 
 /obj/machinery/cryopod/Initialize()
 	old_intercom = locate() in src
@@ -25,6 +26,7 @@
 	return
 
 /obj/machinery/cryopod/set_occupant(var/mob/living/carbon/occupant, var/silent)
+	despawning = FALSE
 	src.occupant = occupant
 	if(!occupant)
 		SetName(initial(name))
@@ -96,6 +98,9 @@
 			var/mob/living/carbon/C = occupant
 			C.SetStasis(2)
 
+		if(despawning)
+			return
+
 		var/time_elapsed = world.time - time_entered
 		var/time_left = round((time_till_despawn - time_elapsed) / (1 SECOND))
 		if((time_left > 0) && ((time_left % 5) == 0))
@@ -116,6 +121,8 @@
 	if(!occupant)
 		return
 
+	despawning = TRUE
+
 	var/role_alt_title = occupant.mind ? occupant.mind.role_alt_title : "Unknown"
 	log_and_message_admins("[key_name(occupant)] ([role_alt_title]) entered cryostorage.")
 	announce.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
@@ -128,16 +135,18 @@
 			var/success = SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
 			if(!success)
 				to_chat(occupant, SPAN_WARNING("Something has gone wrong while deserializing your character. Contact an admin!"))
-				self_eject()
-				audible_message("\The [src] emits a series of warning tones before ejecting the occupant!")
-				return
+				log_and_message_admins("\The cryopod at ([x], [y], [z]) failed to despawn the occupant [occupant]!")
+				audible_message("\The [src] emits a series of warning tones!")
+				return // We don't set despawning here in order to keep the mob safe without continuously retrying despawns.
 			QDEL_NULL(occupant.mind)
 		else
+			despawning = FALSE
 			return
 	if(occupant.ckey)
 		var/mob/new_player/new_player = new()
 		new_player.ckey = occupant.ckey
 
+	despawning = FALSE
 	// Delete the mob.
 	occupant.forceMove(null)
 	qdel(occupant)

--- a/mods/persistence/game/machinery/cryopod.dm
+++ b/mods/persistence/game/machinery/cryopod.dm
@@ -125,7 +125,12 @@
 		H.home_spawn = src
 		var/datum/mind/occupant_mind = occupant.mind
 		if(occupant_mind)
-			SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
+			var/success = SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
+			if(!success)
+				to_chat(occupant, SPAN_WARNING("Something has gone wrong while deserializing your character. Contact an admin!"))
+				self_eject()
+				audible_message("\The [src] emits a series of warning tones before ejecting the occupant!")
+				return
 			QDEL_NULL(occupant.mind)
 		else
 			return

--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -88,6 +88,10 @@
 		to_chat(user, SPAN_DANGER("UNABLE TO FIND SUITABLE LOCATION, CONTACT AN ADMIN!"))
 		message_admins(SPAN_DANGER("UNABLE TO FIND SUITABLE CRYO SPAWN LOCATION FOR CKEY:'[user.ckey]'([user.name])! CREATE A CRYOPOD."))
 
+	// Finally, add the mob to limbo for safety. Mark for removal on the next save.
+	SSpersistence.AddToLimbo(user.mind, user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
+	SSpersistence.limbo_removals += list(list(user.mind.unique_id, LIMBO_MIND))
+
 /obj/machinery/cryopod/chargen/check_occupant_allowed(mob/M)
 	. = ..()
 	if(!.)

--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -68,6 +68,10 @@
 	//Free up the chargen pod
 	unready()
 	SSchargen.release_spawn_pod(get_area(src))
+	
+	// Add the mob to limbo for safety. Mark for removal on the next save.
+	SSpersistence.AddToLimbo(user.mind, user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
+	SSpersistence.limbo_removals += list(list(user.mind.unique_id, LIMBO_MIND))
 
 	for(var/turf/T in global.latejoin_cryo_locations)
 		var/obj/machinery/cryopod/C = locate() in T
@@ -87,10 +91,6 @@
 	else
 		to_chat(user, SPAN_DANGER("UNABLE TO FIND SUITABLE LOCATION, CONTACT AN ADMIN!"))
 		message_admins(SPAN_DANGER("UNABLE TO FIND SUITABLE CRYO SPAWN LOCATION FOR CKEY:'[user.ckey]'([user.name])! CREATE A CRYOPOD."))
-
-	// Finally, add the mob to limbo for safety. Mark for removal on the next save.
-	SSpersistence.AddToLimbo(user.mind, user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
-	SSpersistence.limbo_removals += list(list(user.mind.unique_id, LIMBO_MIND))
 
 /obj/machinery/cryopod/chargen/check_occupant_allowed(mob/M)
 	. = ..()

--- a/mods/persistence/modules/client/preferences.dm
+++ b/mods/persistence/modules/client/preferences.dm
@@ -64,6 +64,11 @@
 		switch(alert("Are you sure you want to finalize your character and join the game with the character you've created?", "Character Confirmation", "Yes", "No"))
 			if("No")
 				return
+		for(var/datum/mind/other_mind in global.player_minds)
+			if(other_mind.name == real_name)
+				to_chat(usr, "<span class='danger'>[real_name] is already a name in use! Please select a different name.</span>")
+				real_name = null
+				return
 		var/DBQuery/char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata2` = '[real_name]'")
 		if(!char_query.Execute())
 			to_world_log("DUPLICATE NAME CHECK DESERIALIZATION FAILED: [char_query.ErrorMsg()].")

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -199,7 +199,7 @@ var/global/list/serialization_time_spent_type
 			if(!GD)
 				// Missing wrapper!
 				continue
-			GD.on_serialize(VV)
+			GD.on_serialize(VV, src)
 			if(!GD.key)
 				// Wrapper is null.
 				continue
@@ -301,7 +301,7 @@ var/global/list/serialization_time_spent_type
 			if(!GD)
 				// Missing wrapper!
 				continue
-			GD.on_serialize(key)
+			GD.on_serialize(key, src)
 			if(!GD.key)
 				// Wrapper is null.
 				continue
@@ -347,7 +347,7 @@ var/global/list/serialization_time_spent_type
 				if(!GD)
 					// Missing wrapper!
 					continue
-				GD.on_serialize(EV)
+				GD.on_serialize(EV, src)
 				if(!GD.key)
 					// Wrapper is null.
 					continue
@@ -437,7 +437,7 @@ var/global/list/serialization_time_spent_type
 					existing.vars[TV.key] = null
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(TV.value)
-					existing.vars[TV.key] = GD.on_deserialize()
+					existing.vars[TV.key] = GD.on_deserialize(src)
 				if(SERIALIZER_TYPE_LIST)
 					// This was just an empty list.
 					if(TV.value == SERIALIZER_TYPE_LIST_EMPTY)
@@ -482,7 +482,7 @@ var/global/list/serialization_time_spent_type
 					key_value = text2path(LE.key)
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(LE.key)
-					key_value = GD.on_deserialize()
+					key_value = GD.on_deserialize(src)
 				if(SERIALIZER_TYPE_LIST)
 					if(LE.key == SERIALIZER_TYPE_LIST_EMPTY)
 						key_value = list()
@@ -508,7 +508,7 @@ var/global/list/serialization_time_spent_type
 					existing[key_value] = text2path(LE.value)
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(LE.value)
-					existing[key_value] = GD.on_deserialize()
+					existing[key_value] = GD.on_deserialize(src)
 				if(SERIALIZER_TYPE_LIST)
 					if(LE.value == SERIALIZER_TYPE_LIST_EMPTY)
 						existing[key_value] = list()

--- a/mods/persistence/modules/world_save/wrappers/_late_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/_late_wrapper.dm
@@ -4,7 +4,7 @@
 
 /datum/wrapper/late
 
-/datum/wrapper/late/on_deserialize()
+/datum/wrapper/late/on_deserialize(var/datum/object, var/serializer/curr_serializer)
 	SSpersistence.late_wrappers |= src
 	return null
 

--- a/mods/persistence/modules/world_save/wrappers/_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/_wrapper.dm
@@ -3,7 +3,7 @@
 	var/wrapper_for
 
 // called after object is deserialized while in the serializer. Return a reference to the game data key is pointing to.
-/datum/wrapper/proc/on_deserialize()
+/datum/wrapper/proc/on_deserialize(var/datum/object, var/serializer/curr_serializer)
 
 // called during serialization for custom behaviour. Assign var/key with something that can be used to restore the game data on_deserialize(). Return nothing.
-/datum/wrapper/proc/on_serialize(var/datum/object)
+/datum/wrapper/proc/on_serialize(var/datum/object, var/serializer/curr_serializer)

--- a/mods/persistence/modules/world_save/wrappers/area_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/area_wrapper.dm
@@ -6,7 +6,10 @@
 	var/list/turfs
 	var/has_gravity
 
-/datum/wrapper/area/on_serialize(var/area/A)
+// TODO: All of this is terrible, and needs to be rewritten to handle references to areas and to
+// prevent massive strings from being in the database.
+
+/datum/wrapper/area/on_serialize(var/area/A, var/serializer/curr_serializer)
 	key = "[A.type]"
 	name = A.name
 
@@ -29,7 +32,7 @@
 	. = ..()
 	turfs.Cut()
 
-/datum/wrapper/area/on_deserialize()	
+/datum/wrapper/area/on_deserialize(var/serializer/curr_serializer)	
 	// Check for areas that have already been deserialized to prevent duplicate areas.
 	for(var/area/pre_area)
 		if("[pre_area.type]" == key && pre_area.name == name)

--- a/mods/persistence/modules/world_save/wrappers/decl_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/decl_wrapper.dm
@@ -1,8 +1,8 @@
 /datum/wrapper/decl
 	wrapper_for = /decl
 
-/datum/wrapper/decl/on_serialize(var/decl/D)
+/datum/wrapper/decl/on_serialize(var/decl/D, var/serializer/curr_serializer)
 	key = "[D.type]"
 
-/datum/wrapper/decl/on_deserialize()
+/datum/wrapper/decl/on_deserialize(var/serializer/curr_serializer)
 	return GET_DECL(text2path(key))

--- a/mods/persistence/modules/world_save/wrappers/extensions/_extension_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/extensions/_extension_wrapper.dm
@@ -3,7 +3,7 @@
 	var/holder_p_id
 	var/list/extension_saved_vars = list()
 
-/datum/wrapper/late/extension/on_serialize(datum/extension/object)
+/datum/wrapper/late/extension/on_serialize(datum/extension/object, serializer/curr_serializer)
 	. = ..()
 	if(!object.holder)
 		return

--- a/mods/persistence/modules/world_save/wrappers/image_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/image_wrapper.dm
@@ -11,7 +11,7 @@
 	var/pixel_y = 0
 	var/appearance_flags
 
-/datum/wrapper/image/on_serialize(var/image/I)
+/datum/wrapper/image/on_serialize(var/image/I, var/serializer/curr_serializer)
 	key = "[I.icon]"
 
 	icon_state = I.icon_state
@@ -23,7 +23,7 @@
 	pixel_y = I.pixel_y
 	appearance_flags = I.appearance_flags
 
-/datum/wrapper/image/on_deserialize()
+/datum/wrapper/image/on_deserialize(var/serializer/curr_serializer)
 	var/image/I = image(icon=file(key), icon_state=icon_state, dir=dir, pixel_x=pixel_x, pixel_y=pixel_y, layer=layer)
 	I.color = color
 	I.alpha = alpha

--- a/mods/persistence/modules/world_save/wrappers/map_data_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/map_data_wrapper.dm
@@ -7,14 +7,14 @@
 	var/height
 	var/landmark_loc
 
-/datum/wrapper/map_data/on_serialize(var/obj/abstract/map_data/M)
+/datum/wrapper/map_data/on_serialize(var/obj/abstract/map_data/M, var/serializer/curr_serializer)
 	key = "[M.type]"
 
 	var/turf/T = get_turf(M)
 	height = M.height
 	landmark_loc = "[T.x],[T.y],[T.z]"
 	
-/datum/wrapper/map_data/on_deserialize()
+/datum/wrapper/map_data/on_deserialize(var/serializer/curr_serializer)
 	var/list/coords = splittext(landmark_loc, ",")
 	var/turf/T = locate(text2num(coords[1]), text2num(coords[2]), text2num(coords[3]))
 	return new /obj/abstract/map_data(T, text2num(height))

--- a/mods/persistence/modules/world_save/wrappers/weakref_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/weakref_wrapper.dm
@@ -1,12 +1,10 @@
 /datum/wrapper/weakref
 	wrapper_for = /weakref
 
-/datum/wrapper/weakref/on_serialize(var/weakref/W)
-	var/serializer/S = SSpersistence.serializer
-	key = S.SerializeDatum(W.resolve()) // Returns the thing ID if the referenced object is serialized, or serializes it if not.
+/datum/wrapper/weakref/on_serialize(var/weakref/W, var/serializer/curr_serializer)
+	key = curr_serializer.SerializeDatum(W.resolve(), src) // Returns the thing ID if the referenced object is serialized, or serializes it if not.
 
-/datum/wrapper/weakref/on_deserialize()
-	var/serializer/S = SSpersistence.serializer
-	var/datum/thing = S.QueryAndDeserializeDatum(key)
+/datum/wrapper/weakref/on_deserialize(var/serializer/curr_serializer)
+	var/datum/thing = curr_serializer.QueryAndDeserializeDatum(key)
 	var/weakref/ref = weakref(thing)
 	return ref


### PR DESCRIPTION
A few adjustments to limbo saving and new player code for safeties sake.
* New player code for spawning in as characters from limbo/deleting characters now use the save database connection, closing and opening as required.
* Things that are queued to be removed from limbo are now removed from the queue after removal. This was a likely cause of previous character loss from limbo.
* Despawner cryopods now check to see if the character was serialized before qdel'ing the mob.
* Characters are no longer added to limbo immediately upon creation, but only upon arriving on Kleibkhar.
* Wrappers now have the serializer passed, fixing weakref saving with limbo serialization. This was causing the loss of custom saved lists on humans *specifically for limbo saving* (the other loss was due to the gas mixture bug, which has been resolved).