### PR TITLE
Kleibkhar area fixes [MDB IGNORE] [DNM]

### DIFF
--- a/maps/kleibkhar/kleibkhar-1.dmm
+++ b/maps/kleibkhar/kleibkhar-1.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/depth_2)
+/area/exoplanet/kleibkhar_mines/depth_2)
 "b" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -12,10 +12,10 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "c" = (
 /turf/simulated/wall/elevator,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "d" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -23,26 +23,26 @@
 	},
 /obj/structure/stairs/long/west,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "e" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "f" = (
 /obj/structure/railing/mapped,
 /obj/structure/stairs/long/west,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "g" = (
 /obj/structure/railing/mapped,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "h" = (
 /turf/exterior/planet_edge,
-/area/exoplanet/kleibkhar/mines/depth_2)
+/area/exoplanet/kleibkhar_mines/depth_2)
 "i" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -53,7 +53,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "j" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -64,7 +64,7 @@
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "k" = (
 /obj/machinery/light/small/emergency/cabled{
 	icon_state = "bulb_map";
@@ -82,7 +82,7 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "l" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -93,7 +93,7 @@
 	icon_state = "1-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "m" = (
 /obj/machinery/light/small/emergency/cabled,
 /obj/effect/decal/cleanable/dirt,
@@ -101,11 +101,11 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "n" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "o" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -116,7 +116,7 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "p" = (
 /obj/machinery/light/small/emergency/cabled{
 	icon_state = "bulb_map";
@@ -131,7 +131,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "q" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -142,12 +142,12 @@
 	icon_state = "1-2"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "r" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "s" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -155,7 +155,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "t" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -166,14 +166,14 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "u" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "v" = (
 /obj/machinery/light/small/emergency/cabled,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -188,16 +188,16 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "w" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced/damaged,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "x" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced/damaged,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "y" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -211,7 +211,7 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "z" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -225,14 +225,14 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "A" = (
 /obj/structure/sign/deck/second{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "B" = (
 /obj/machinery/light/small/emergency/cabled,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -243,7 +243,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "C" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -254,7 +254,7 @@
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "D" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -262,7 +262,7 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "E" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -273,7 +273,7 @@
 	icon_state = "1-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "F" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -282,13 +282,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "G" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "H" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip{
@@ -296,7 +296,7 @@
 	pixel_y = 3
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "I" = (
 /obj/machinery/light/small/emergency/cabled{
 	icon_state = "bulb_map";
@@ -313,14 +313,14 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "J" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "K" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
@@ -328,7 +328,7 @@
 	icon_state = "16-0"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "L" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -336,7 +336,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 
 (1,1,1) = {"
 h

--- a/maps/kleibkhar/kleibkhar-2.dmm
+++ b/maps/kleibkhar/kleibkhar-2.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ab" = (
 /turf/simulated/wall/elevator,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ac" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -12,29 +12,29 @@
 	},
 /obj/structure/stairs/long/west,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ad" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ae" = (
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/depth_1)
+/area/exoplanet/kleibkhar_mines/depth_1)
 "af" = (
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ag" = (
 /obj/structure/railing/mapped,
 /obj/structure/stairs/long/west,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ah" = (
 /obj/structure/railing/mapped,
 /turf/exterior/barren/mining,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ai" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -45,10 +45,10 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aj" = (
 /turf/exterior/planet_edge,
-/area/exoplanet/kleibkhar/mines/depth_1)
+/area/exoplanet/kleibkhar_mines/depth_1)
 "ak" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -59,7 +59,7 @@
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "al" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -70,7 +70,7 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "am" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -81,7 +81,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "an" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -92,7 +92,7 @@
 	icon_state = "1-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ap" = (
 /obj/machinery/light/small/emergency/cabled,
 /obj/effect/decal/cleanable/dirt,
@@ -100,11 +100,11 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ar" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -122,7 +122,7 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "as" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -140,7 +140,7 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "at" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -148,12 +148,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "au" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "av" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -161,7 +161,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aw" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -172,7 +172,7 @@
 	icon_state = "1-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ax" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -183,7 +183,7 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ay" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -201,7 +201,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "az" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -209,23 +209,23 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aA" = (
 /obj/structure/sign/deck/first{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aB" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aC" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aD" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -236,7 +236,7 @@
 	icon_state = "1-2"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aE" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -247,7 +247,7 @@
 	icon_state = "1-2"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aF" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -261,14 +261,14 @@
 	icon_state = "1-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aH" = (
 /obj/structure/sign/deck/first{
 	pixel_y = 24
@@ -285,7 +285,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aI" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -299,7 +299,7 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aJ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -317,7 +317,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aK" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -329,12 +329,12 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aL" = (
 /obj/structure/railing/mapped,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
@@ -342,12 +342,12 @@
 	icon_state = "railing0-1"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aN" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aO" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -362,7 +362,7 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aP" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -370,7 +370,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aQ" = (
 /obj/structure/railing/mapped,
 /obj/effect/decal/cleanable/dirt,
@@ -382,7 +382,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aR" = (
 /obj/structure/sign/deck/first{
 	pixel_y = 24
@@ -397,14 +397,14 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aT" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -416,7 +416,7 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aU" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -431,7 +431,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aW" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -439,7 +439,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aX" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -450,7 +450,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "aZ" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -465,7 +465,7 @@
 	icon_state = "0-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "ba" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	icon_state = "warningcorner_dust";
@@ -476,7 +476,7 @@
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bb" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -484,7 +484,7 @@
 	icon_state = "2-4"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bc" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -496,7 +496,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -504,7 +504,7 @@
 	icon_state = "4-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bh" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -522,7 +522,7 @@
 	icon_state = "0-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bj" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -536,7 +536,7 @@
 	icon_state = "1-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bk" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -550,7 +550,7 @@
 	icon_state = "2-8"
 	},
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -558,18 +558,18 @@
 	},
 /obj/structure/cable/yellow,
 /turf/exterior/concrete/reinforced,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bm" = (
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 "bn" = (
 /obj/structure/lattice,
 /obj/structure/cable/yellow{
 	icon_state = "32-1"
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/mines/exits)
+/area/exoplanet/kleibkhar_mines/exits)
 
 (1,1,1) = {"
 aj

--- a/maps/kleibkhar/kleibkhar-3.dmm
+++ b/maps/kleibkhar/kleibkhar-3.dmm
@@ -1423,7 +1423,7 @@
 /area/kleibkhar/outpost/mess_hall)
 "dC" = (
 /turf/simulated/floor/plating,
-/area/exoplanet/kleibkhar/supply_shuttle_dock)
+/area/exoplanet/kleibkhar_supply_shuttle_dock)
 "dD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1657,7 +1657,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/exoplanet/kleibkhar/supply_shuttle_dock)
+/area/exoplanet/kleibkhar_supply_shuttle_dock)
 "ee" = (
 /obj/structure/cable{
 	icon_state = "4-8"

--- a/maps/kleibkhar/kleibkhar-4.dmm
+++ b/maps/kleibkhar/kleibkhar-4.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/exterior/planet_edge,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ab" = (
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ac" = (
 /obj/abstract/map_data{
 	height = 4
 	},
 /obj/effect/overmap/visitable/sector/exoplanet/kleibkhar,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ad" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -22,14 +22,14 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ae" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "af" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -40,24 +40,24 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ag" = (
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ah" = (
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ai" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aj" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -68,7 +68,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ak" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -79,7 +79,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "al" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -90,14 +90,14 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "am" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "an" = (
 /obj/structure/cable{
 	icon_state = "32-4"
@@ -116,7 +116,7 @@
 	dir = 8
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ao" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -130,7 +130,7 @@
 	icon_state = "11-scrubbers"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ap" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -144,7 +144,7 @@
 	dir = 10
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -152,11 +152,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ar" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "as" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -164,7 +164,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "at" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -172,7 +172,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "au" = (
 /obj/machinery/atmospherics/unary/outlet_injector/cabled/on{
 	icon_state = "off";
@@ -197,7 +197,7 @@
 	},
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ax" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -205,7 +205,7 @@
 	},
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
@@ -234,7 +234,7 @@
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aC" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -243,7 +243,7 @@
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aD" = (
 /obj/structure/cable{
 	icon_state = "32-4"
@@ -262,7 +262,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -273,7 +273,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aF" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -287,7 +287,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -301,7 +301,7 @@
 	dir = 6
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -315,7 +315,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -332,18 +332,18 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aL" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -351,7 +351,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aM" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -363,7 +363,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aN" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -382,7 +382,7 @@
 	icon_state = "32-4"
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -396,7 +396,7 @@
 	dir = 9
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aP" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -405,12 +405,12 @@
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aQ" = (
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -427,7 +427,7 @@
 	dir = 5
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -441,13 +441,13 @@
 	dir = 9
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aU" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -459,7 +459,7 @@
 	},
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aV" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -467,7 +467,7 @@
 	},
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aW" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -475,7 +475,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aX" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -483,11 +483,11 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aY" = (
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "aZ" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -495,7 +495,7 @@
 	dir = 4
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "ba" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -503,7 +503,7 @@
 	dir = 8
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bb" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -516,7 +516,7 @@
 	dir = 8
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bc" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -525,14 +525,14 @@
 	dir = 1
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bd" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "be" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -543,7 +543,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bf" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -552,24 +552,24 @@
 	dir = 8
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bg" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bh" = (
 /obj/structure/cable{
 	icon_state = "32-4"
 	},
 /obj/structure/lattice,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bi" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bj" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -579,13 +579,13 @@
 	dir = 8
 	},
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bk" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/railing/mapped,
 /turf/exterior/open,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bl" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing_preview";
@@ -593,7 +593,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor,
-/area/exoplanet/kleibkhar/sky)
+/area/exoplanet/kleibkhar_sky)
 "bm" = (
 /obj/machinery/atmospherics/unary/vent_pump/cabled/siphon/on{
 	icon_state = "map_vent_in";

--- a/maps/kleibkhar/kleibkhar_areas.dm
+++ b/maps/kleibkhar/kleibkhar_areas.dm
@@ -94,13 +94,14 @@
 	open_turf = /turf/exterior/barren //For now
 	is_outside = OUTSIDE_YES
 
-/area/exoplanet/kleibkhar/sky
+/area/exoplanet/kleibkhar_sky
 	name = "Up Above"
 	icon_state = "blueold"
 	base_turf = /turf/exterior/open
 	open_turf = /turf/exterior/open
+	is_outside = OUTSIDE_YES
 
-/area/exoplanet/kleibkhar/mines
+/area/exoplanet/kleibkhar_mines
 	name = "Deep Underground"
 	icon_state = "cave"
 	ignore_mining_regen = TRUE
@@ -109,21 +110,21 @@
 	open_turf = /turf/exterior/open
 	area_flags = AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_BACKGROUND | AREA_FLAG_ION_SHIELDED | AREA_FLAG_RAD_SHIELDED
 
-/area/exoplanet/kleibkhar/mines/depth_1
+/area/exoplanet/kleibkhar_mines/depth_1
 	icon_state = "cave"
 	ignore_mining_regen = FALSE
 
-/area/exoplanet/kleibkhar/mines/depth_2
+/area/exoplanet/kleibkhar_mines/depth_2
 	name = "Deepest Underground"
 	icon_state = "cave"
 	ignore_mining_regen = FALSE
 
-/area/exoplanet/kleibkhar/mines/exits
+/area/exoplanet/kleibkhar_mines/exits
 	name = "Mine Exit"
 	icon_state = "exit"
 	area_flags = AREA_FLAG_IS_BACKGROUND | AREA_FLAG_ION_SHIELDED | AREA_FLAG_RAD_SHIELDED
 
-/area/exoplanet/kleibkhar/supply_shuttle_dock
+/area/exoplanet/kleibkhar_supply_shuttle_dock
 	name = "Supply Shuttle Dock"
 	icon_state = "yellow"
 	base_turf = /turf/simulated/floor/plating //Needed for shuttles

--- a/maps/kleibkhar/kleibkhar_overmap.dm
+++ b/maps/kleibkhar/kleibkhar_overmap.dm
@@ -27,7 +27,7 @@
 /obj/effect/shuttle_landmark/supply/station
 	landmark_tag = "nav_cargo_station"
 	docking_controller = "cargo_bay"
-	base_area = /area/exoplanet/kleibkhar/supply_shuttle_dock
+	base_area = /area/exoplanet/kleibkhar_supply_shuttle_dock
 	base_turf = /turf/simulated/floor/plating
 
 //supply


### PR DESCRIPTION
Makes the Kleibkhar exoplanet areas no longer subtypes. This fixes the bug where the area left behind by docking beacons was not the base exoplanet area, but this is arguably not the correct way to fix this, so leaving it as DNM for now.