### PR TITLE
Adjusts storage saving

### DIFF
--- a/mods/persistence/game/objects/items/weapons/storage.dm
+++ b/mods/persistence/game/objects/items/weapons/storage.dm
@@ -16,9 +16,32 @@
 		slot_size = max_w_class
 	. = ..()
 
-SAVED_VAR(/obj/item/storage, can_hold)
-SAVED_VAR(/obj/item/storage, cant_hold)
-
+SAVED_VAR(/obj/item/storage, opened)
 // We only save them for this subtype, since they generate them during runtime.
 SAVED_VAR(/obj/item/storage/internal/pockets, storage_slots)
 SAVED_VAR(/obj/item/storage/internal/pockets, max_w_class)
+
+// Only subtypes which call make_exact_fit() need to save these variables.
+SAVED_VAR(/obj/item/storage/box/glasses, can_hold)
+SAVED_VAR(/obj/item/storage/box/glasses, storage_slots)
+
+SAVED_VAR(/obj/item/storage/box/mixed_glasses, can_hold)
+SAVED_VAR(/obj/item/storage/box/mixed_glasses, storage_slots)
+
+SAVED_VAR(/obj/item/storage/csi_markers, can_hold)
+SAVED_VAR(/obj/item/storage/csi_markers, storage_slots)
+
+SAVED_VAR(/obj/item/storage/secure/briefcase/heavysniper, can_hold)
+SAVED_VAR(/obj/item/storage/secure/briefcase/heavysniper, storage_slots)
+
+SAVED_VAR(/obj/item/storage/mre, can_hold)
+SAVED_VAR(/obj/item/storage/mre, storage_slots)
+
+SAVED_VAR(/obj/item/storage/med_pouch, can_hold)
+SAVED_VAR(/obj/item/storage/med_pouch, storage_slots)
+
+SAVED_VAR(/obj/item/storage/box/lights, can_hold)
+SAVED_VAR(/obj/item/storage/box/lights, storage_slots)
+
+SAVED_VAR(/obj/item/storage/bible, can_hold)
+SAVED_VAR(/obj/item/storage/bible, storage_slots)


### PR DESCRIPTION
## Description of changes
A commit from my previous gun and storage saving PR which I had forgotten to commit. Only subtypes of storage which change their ``can_hold`` and ``storage_slots`` variables now do so. Storage items also save their ``opened`` variable, which is used for things like medpouches which must be opened before use.
