### PR TITLE
makes it so gloves and shoes can be seen while wearing a chemsuit

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -161,7 +161,7 @@
 	w_class = ITEM_SIZE_HUGE//bulky item
 	gas_transfer_coefficient = 0
 	permeability_coefficient = 0
-	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_LEGS|SLOT_FEET|SLOT_ARMS|SLOT_HANDS
+	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_LEGS|SLOT_ARMS
 	allowed = list(/obj/item/tank/emergency,/obj/item/pen,/obj/item/flashlight/pen,/obj/item/scanner/health,/obj/item/ano_scanner,/obj/item/clothing/head/chem_hood,/obj/item/clothing/mask/gas,/obj/item/geiger)
 	armor = list(
 		bio = ARMOR_BIO_RESISTANT, 

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -156,7 +156,7 @@
 
 /obj/item/clothing/suit/chem_suit
 	name = "chemical suit"
-	desc = "A suit that protects against chemical contamination."
+	desc = "A suit that protects against chemical contamination and acidic atmospheres."
 	icon = 'icons/clothing/suit/chem_suit.dmi'
 	w_class = ITEM_SIZE_HUGE//bulky item
 	gas_transfer_coefficient = 0
@@ -167,7 +167,7 @@
 		bio = ARMOR_BIO_RESISTANT, 
 		rad = ARMOR_RAD_MINOR
 		)
-	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
+	flags_inv = HIDEJUMPSUIT|HIDETAIL
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	siemens_coefficient = 0.9
 	matter = list(


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Recently I updated the sprite of the chemsuit. Unfortunately, I wasn't aware that the previous sprite actually hid your gloves and shoes - the new sprite doesn't cover the shoes and hands, so wearing it will make your character look barefoot and barehanded.

This quick modification makes it so shoes are actually visible under the chemsuit.

Also adds a little bit to the description to clarify that the suit protects against acidic atmospheres, like the chlorine on Outreach.

## Why and what will this PR improve
Makes the chemsuit less ugly.

## Authorship
genessee

## Changelog
:cl:
fix: the chemsuit now properly shows worn shoes and gloves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->