### PR TITLE
Miscellaneous load fixes [MDB IGNORE] [IDB IGNORE]

### DIFF
--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -128,6 +128,7 @@
 #include "modules\lighting\lighting_overlay.dm"
 #include "modules\materials\definitions\materials_stone.dm"
 #include "modules\materials\geology\_strata.dm"
+#include "modules\mining\machinery\_material_processing.dm"
 #include "modules\mining\machinery\material_compressor.dm"
 #include "modules\mining\machinery\material_smelter.dm"
 #include "modules\mob\death.dm"

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -108,6 +108,7 @@
 #include "modules\cloning\machines\cloning_pod.dm"
 #include "modules\clothing\_clothing.dm"
 #include "modules\clothing\spacesuits.dm"
+#include "modules\clothing\suits\storage.dm"
 #include "modules\clothing\under\accessories\storage.dm"
 #include "modules\detectivework\forensics_designs.dm"
 #include "modules\detectivework\evidence\_evidence_holder.dm"

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -112,7 +112,7 @@
 			if(istype(MA) && !(MA.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
 				if(((MA in SSpersistence.saved_areas) || (current_mob.z in SSpersistence.saved_levels)))
 					continue
-			one_off.AddToLimbo(char_mind, char_mind.unique_id, LIMBO_MIND, char_mind.key, char_mind.current.real_name, TRUE)
+			one_off.AddToLimbo(list(current_mob, char_mind), char_mind.unique_id, LIMBO_MIND, char_mind.key, current_mob.real_name, TRUE)
 		report_progress("Done adding player minds to limbo in [(REALTIMEOFDAY - time_start_limbo_minds) / (1 SECOND)]s.")
 		sleep(5)
 
@@ -558,13 +558,13 @@
 	to_chat(user, SPAN_INFO("Disabled with persistence modpack (how ironic)..."))
 	return
 
-/datum/controller/subsystem/persistence/proc/AddToLimbo(var/datum/thing, var/key, var/limbo_type, var/metadata, var/metadata2, var/modify = TRUE)
+/datum/controller/subsystem/persistence/proc/AddToLimbo(var/list/things, var/key, var/limbo_type, var/metadata, var/metadata2, var/modify = TRUE)
 	var/new_db_connection = FALSE
 	if(!check_save_db_connection())
 		if(!establish_save_db_connection())
 			CRASH("SSPersistence: Couldn't establish DB connection during Limbo Addition!")
 		new_db_connection = TRUE
-	. = one_off.AddToLimbo(thing, key, limbo_type, metadata, metadata2, modify)
+	. = one_off.AddToLimbo(things, key, limbo_type, metadata, metadata2, modify)
 	if(.) // Clear it from the queued removals.
 		for(var/list/queued in limbo_removals)
 			if(queued[1] == key && queued[2] == limbo_type)

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -417,6 +417,7 @@
 					var/new_type = text2path(area_chunk[1])
 					var/area/new_area = new new_type 
 					new_area.name = area_chunk[2]
+					new_area.proper_name = strip_improper(new_area.name)
 					area_dict["[new_area.type], [area_chunk[2]]"] = new_area
 			// The areas are split into horizontal chunks with the area type and name corresponding to a certain amount of tiles in a row.
 			var/chunk_index = 1
@@ -453,6 +454,7 @@
 			if(!new_area)
 				new_area = new area_chunk.area_type
 				new_area.name = area_chunk.name
+				new_area.proper_name = strip_improper(new_area.name)
 				area_dict["[area_chunk.area_type], [area_chunk.name]"] = new_area
 
 			for(var/turf_chunk in area_chunk.turfs)

--- a/mods/persistence/game/machinery/cryopod.dm
+++ b/mods/persistence/game/machinery/cryopod.dm
@@ -132,7 +132,7 @@
 		H.home_spawn = src
 		var/datum/mind/occupant_mind = occupant.mind
 		if(occupant_mind)
-			var/success = SSpersistence.AddToLimbo(occupant_mind, occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
+			var/success = SSpersistence.AddToLimbo(list(occupant, occupant_mind), occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
 			if(!success)
 				to_chat(occupant, SPAN_WARNING("Something has gone wrong while deserializing your character. Contact an admin!"))
 				log_and_message_admins("\The cryopod at ([x], [y], [z]) failed to despawn the occupant [occupant]!")

--- a/mods/persistence/game/machinery/machinery.dm
+++ b/mods/persistence/game/machinery/machinery.dm
@@ -28,6 +28,8 @@ SAVED_VAR(/obj/machinery, req_access)
 
 SAVED_VAR(/obj/machinery/power/terminal,  master)
 
+SAVED_VAR(/obj/machinery/constructable_frame, circuit)
+
 SAVED_VAR(/obj/item/stock_parts, status)
 SAVED_VAR(/obj/item/stock_parts, req_access)
 

--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -70,7 +70,7 @@
 	SSchargen.release_spawn_pod(get_area(src))
 	
 	// Add the mob to limbo for safety. Mark for removal on the next save.
-	SSpersistence.AddToLimbo(user.mind, user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
+	SSpersistence.AddToLimbo(list(user, user.mind), user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
 	SSpersistence.limbo_removals += list(list(user.mind.unique_id, LIMBO_MIND))
 
 	for(var/turf/T in global.latejoin_cryo_locations)

--- a/mods/persistence/modules/clothing/suits/storage.dm
+++ b/mods/persistence/modules/clothing/suits/storage.dm
@@ -1,0 +1,10 @@
+// Override since storage recreates pockets on load.
+// TODO: Move the creation upstream to a new proc.
+/obj/item/clothing/suit/storage/Initialize()
+	if(persistent_id && pockets)
+		var/old_pockets = pockets
+		. = ..()
+		QDEL_NULL(pockets)
+		pockets = old_pockets
+	else
+		return ..()

--- a/mods/persistence/modules/mining/machinery/_material_processing.dm
+++ b/mods/persistence/modules/mining/machinery/_material_processing.dm
@@ -1,0 +1,18 @@
+/obj/machinery/material_processing/before_save()
+	. = ..()
+	if(input_turf)
+		CUSTOM_SV("input_dir", get_dir(src, input_turf))
+	if(output_turf)
+		CUSTOM_SV("output_dir", get_dir(src, output_turf))
+
+/obj/machinery/material_processing/after_deserialize()
+	. = ..()
+	var/input_dir = LOAD_CUSTOM_SV("input_dir")
+	if(input_dir)
+		input_turf = input_dir
+		CLEAR_SV("input_dir")
+
+	var/output_dir = LOAD_CUSTOM_SV("output_dir")
+	if(output_dir)
+		output_turf = output_dir
+		CLEAR_SV("output_dir")

--- a/mods/persistence/modules/world_save/saved_vars/saved_misc.dm
+++ b/mods/persistence/modules/world_save/saved_vars/saved_misc.dm
@@ -790,9 +790,6 @@ SAVED_VAR(/obj/machinery/material_processing/smeltery, casting)
 SAVED_VAR(/obj/machinery/material_processing/smeltery, show_all_materials)
 SAVED_VAR(/obj/machinery/material_processing/smeltery, show_materials)
 
-SAVED_VAR(/obj/machinery/material_processing, input_turf)
-SAVED_VAR(/obj/machinery/material_processing, output_turf)
-
 SAVED_VAR(/obj/machinery/navbeacon, locked)
 SAVED_VAR(/obj/machinery/navbeacon, location)
 SAVED_VAR(/obj/machinery/navbeacon, codes)

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -399,11 +399,7 @@ var/global/list/serialization_time_spent_type
 		if (!T)
 			to_world_log("Attempting to deserialize onto turf [thing.x],[thing.y],[thing.z] failed. Could not locate turf.")
 			return
-
-		//Don't use change turf, or it'll regen ao and shadows and create weird artifacts
-		T.changing_turf = TRUE
-		qdel(T)
-		existing = new thing.thing_type(T)
+		existing = T.ChangeTurf(thing.thing_type)
 	else
 		// default creation
 		existing = new thing.thing_type()

--- a/mods/persistence/modules/world_save/wrappers/area_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/area_wrapper.dm
@@ -18,4 +18,5 @@
 	var/new_type = text2path(key)
 	var/area/A = new new_type
 	A.name = name
+	A.proper_name = strip_improper(A.name)
 	return A


### PR DESCRIPTION
## Description of changes
Depends on https://github.com/PersistentSS13/Nebula/pull/339. Fixes a few load issues we've encountered.
* Turfs now once again use ChangeTurf() on load. Due to changes upstream, this is almost identical behavior as before, albeit without qdeling the turf. This is critical, as qdeling the turf apparently resulted in the ``garbage.dm`` runtimes we previously encountered, and also set ``gc_destroyed`` on the turf. This resulted in a host of issues, with a notable player facing one being that you could not crowbar up flooring on loaded turfs.
* Machinery frames now save their ``circuit`` variable, allowing you to crowbar it out after load.
* Material processing machinery now saves their input and output directions.
* Storage clothing will now load their pockets correctly, instead of overwriting them.
* Areas will now load their names properly by setting ``proper_name``
* Limbo saving will now explicitly save the mob in addition to the mind. This normally shouldn't matter, but it will make limbo saving fail if for some reason it only manages to save the mind and not the body.

## Authorship
Myself. Thanks to Toby et. al for these reports today.

## Changelog
:cl:
fix: Fixed being unable to crowbar up flooring on load
fix: Fixed machinery frames losing their circuits on load
fix: Fixed storage clothing now saving their internal items
fix: Fixed areas not having the correct names on load
fix: Fixed material processing machinery not their input and output saved on load
/:cl: