### PR TITLE
Add remove limbo entry verb

### DIFF
--- a/mods/persistence/__defines/logging.dm
+++ b/mods/persistence/__defines/logging.dm
@@ -1,0 +1,3 @@
+/proc/report_progress_serializer(var/progress_message)
+	admin_notice("<span class='boldannounce' style='color:\"purple\";'>[progress_message]</span>", R_DEBUG)
+	to_world_log(progress_message)

--- a/mods/persistence/_persistence.dm
+++ b/mods/persistence/_persistence.dm
@@ -3,12 +3,8 @@
 
 /decl/modpack/persistence/initialize()
 	. = ..()
-	admin_verbs_admin.Add(/client/proc/save_server)
-	admin_verbs_admin.Add(/client/proc/regenerate_mine)
-	admin_verbs_admin.Add(/client/proc/database_status)
-	admin_verbs_admin.Add(/client/proc/database_reconect)
-	admin_verbs_admin.Add(/client/proc/remove_character)
-	
+	admin_verbs_admin.Add(global.persistence_admin_verbs)
+
 	admin_verbs_admin.Remove(/client/proc/admin_call_shuttle)
 	admin_verbs_admin.Remove(/client/proc/admin_cancel_shuttle)
 	admin_verbs_admin.Remove(/client/proc/check_ai_laws)

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -6,6 +6,7 @@
 #include "random_phrase.dm"
 #include "sequential_guid.dm"
 #include "__defines\area_saving.dm"
+#include "__defines\logging.dm"
 #include "__defines\saved_var.dm"
 #include "__defines\seed_saving_helper.dm"
 #include "__defines\serializer.dm"

--- a/mods/persistence/controllers/subsystems/mapping.dm
+++ b/mods/persistence/controllers/subsystems/mapping.dm
@@ -6,9 +6,9 @@
 #ifndef UNIT_TEST
 	var/save_exists = SSpersistence.SaveExists()
 	if(save_exists)
-		report_progress("Existing save found.")
+		report_progress_serializer("Existing save found.")
 	else 
-		report_progress("No existing save found.")
+		report_progress_serializer("No existing save found.")
 #endif
 	// Load our maps dynamically.
 	for(var/z in global.using_map.default_levels)
@@ -30,10 +30,10 @@
 			O.late_initialize()
 	// Build the list of static persisted levels from our map.
 #ifdef UNIT_TEST
-	report_progress("Unit testing, so not loading saved map")
+	report_progress_serializer("Unit testing, so not loading saved map")
 #else
 	if(save_exists)
-		report_progress("Loading world save.")
+		report_progress_serializer("Loading world save.")
 		SSpersistence.LoadWorld()
 #endif
 

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -58,32 +58,32 @@
 		// Prepare atmosphere for saving.
 		SSair.can_fire = FALSE
 		if (SSair.state != SS_IDLE)
-			report_progress("ZAS Rebuild initiated. Waiting for current air tick to complete before continuing.")
+			report_progress_serializer("ZAS Rebuild initiated. Waiting for current air tick to complete before continuing.")
 			sleep(5)
 		while (SSair.state != SS_IDLE)
 			stoplag()
 
 		// Prepare all atmospheres to save.
-		report_progress("Storing pipenet air..")
+		report_progress_serializer("Storing pipenet air..")
 		sleep(5)
 		var/time_start_pipenet = REALTIMEOFDAY
 		for(var/datum/pipe_network/net in SSmachines.pipenets)
 			for(var/datum/pipeline/line in net.line_members)
 				line.temporarily_store_fluids()
-		report_progress("Pipenet air stored in [(REALTIMEOFDAY - time_start_pipenet) / (1 SECOND)]s")
+		report_progress_serializer("Pipenet air stored in [(REALTIMEOFDAY - time_start_pipenet) / (1 SECOND)]s")
 		sleep(5)
 
-		report_progress("Invalidating all airzones..")
+		report_progress_serializer("Invalidating all airzones..")
 		sleep(5)
 		var/time_start_airzones = REALTIMEOFDAY
 		while (SSair.zones.len)
 			var/zone/zone = SSair.zones[SSair.zones.len]
 			SSair.zones.len--
 			zone.c_invalidate()
-		report_progress("Invalidated in [(REALTIMEOFDAY - time_start_airzones) / (1 SECOND)]s")
+		report_progress_serializer("Invalidated in [(REALTIMEOFDAY - time_start_airzones) / (1 SECOND)]s")
 		sleep(5)
 
-		report_progress("Removing queued limbo objects..")
+		report_progress_serializer("Removing queued limbo objects..")
 		sleep(5)
 
 		var/time_start_limbo_removal = REALTIMEOFDAY
@@ -92,10 +92,10 @@
 			limbo_removals -= list(queued)
 
 		limbo_refs.Cut()
-		report_progress("Done removing queued limbo objects in [(REALTIMEOFDAY - time_start_limbo_removal) / (1 SECOND)]s.")
+		report_progress_serializer("Done removing queued limbo objects in [(REALTIMEOFDAY - time_start_limbo_removal) / (1 SECOND)]s.")
 		sleep(5)
 
-		report_progress("Adding limbo players minds to limbo..")
+		report_progress_serializer("Adding limbo players minds to limbo..")
 		sleep(5)
 		var/time_start_limbo_minds = REALTIMEOFDAY
 		// Find all the minds gameworld and add any player characters to the limbo list.
@@ -113,22 +113,22 @@
 				if(((MA in SSpersistence.saved_areas) || (current_mob.z in SSpersistence.saved_levels)))
 					continue
 			one_off.AddToLimbo(list(current_mob, char_mind), char_mind.unique_id, LIMBO_MIND, char_mind.key, current_mob.real_name, TRUE)
-		report_progress("Done adding player minds to limbo in [(REALTIMEOFDAY - time_start_limbo_minds) / (1 SECOND)]s.")
+		report_progress_serializer("Done adding player minds to limbo in [(REALTIMEOFDAY - time_start_limbo_minds) / (1 SECOND)]s.")
 		sleep(5)
 
-		report_progress("Wiping previous save..")
+		report_progress_serializer("Wiping previous save..")
 		sleep(5)
 		var/time_start_wipe = REALTIMEOFDAY
 		// Wipe the previous save.
 		serializer.WipeSave()
-		report_progress("Done wiping previous save in [(REALTIMEOFDAY - time_start_wipe) / (1 SECOND)]s.")
+		report_progress_serializer("Done wiping previous save in [(REALTIMEOFDAY - time_start_wipe) / (1 SECOND)]s.")
 		sleep(5)
 
 		//
 		// 	ACTUAL SAVING SECTION
 		//
 
-		report_progress("Preparing z-levels for save..")
+		report_progress_serializer("Preparing z-levels for save..")
 		sleep(5)
 		var/time_start_zprepare = REALTIMEOFDAY
 		// This will prepare z_level translations.
@@ -179,10 +179,10 @@
 		new_z_index++
 		serializer.z_index = new_z_index
 
-		report_progress("Z-levels prepared for save in [(REALTIMEOFDAY - time_start_zprepare) / (1 SECOND)]s.")
+		report_progress_serializer("Z-levels prepared for save in [(REALTIMEOFDAY - time_start_zprepare) / (1 SECOND)]s.")
 		sleep(5)
 
-		report_progress("Saving z-level turfs..")
+		report_progress_serializer("Saving z-level turfs..")
 		sleep(5)
 		var/time_start_zsave = REALTIMEOFDAY
 		// This will save all the turfs/world.
@@ -246,14 +246,14 @@
 			serializer.Commit() // cleanup leftovers.
 			serializer.CommitRefUpdates()
 			++progress
-			report_progress("Working.. [(progress * 100) / max_progress]%")
+			report_progress_serializer("Working.. [(progress * 100) / max_progress]%")
 			sleep(3)
 
 		index = 1
-		report_progress("Z-levels turfs saved in [(REALTIMEOFDAY - time_start_zsave) / (1 SECOND)]s.")
+		report_progress_serializer("Z-levels turfs saved in [(REALTIMEOFDAY - time_start_zsave) / (1 SECOND)]s.")
 		sleep(5)
 
-		report_progress("Saving z-level areas..")
+		report_progress_serializer("Saving z-level areas..")
 		sleep(5)
 		var/time_start_zarea = REALTIMEOFDAY
 		// Repeat much of the above code in order to save areas marked to be saved that are not in a saved z-level.
@@ -302,10 +302,10 @@
 		serializer.Commit()
 		serializer.CommitRefUpdates()
 
-		report_progress("Z-levels areas saved in [(REALTIMEOFDAY - time_start_zarea) / (1 SECOND)]s.")
+		report_progress_serializer("Z-levels areas saved in [(REALTIMEOFDAY - time_start_zarea) / (1 SECOND)]s.")
 		sleep(5)
 
-		report_progress("Saving extensions...")
+		report_progress_serializer("Saving extensions...")
 		// Now save all the extensions which have marked themselves to be saved.
 		// As with areas, we create a dummy wrapper holder to hold these during load etc.
 		var/datum/wrapper_holder/extension_wrapper_holder = new(saved_extensions)
@@ -313,7 +313,7 @@
 		serializer.Serialize(extension_wrapper_holder)
 		serializer.Commit()
 
-		report_progress("Extensions saved in [(REALTIMEOFDAY - time_start_extensions) / (1 SECOND)]s.")
+		report_progress_serializer("Extensions saved in [(REALTIMEOFDAY - time_start_extensions) / (1 SECOND)]s.")
 		sleep(5)
 
 		//

--- a/mods/persistence/modules/admin/verbs/admin.dm
+++ b/mods/persistence/modules/admin/verbs/admin.dm
@@ -1,3 +1,13 @@
+/**Admin verbs that will be added to the main admin verb list. */
+var/global/list/persistence_admin_verbs = list(
+	/client/proc/save_server,
+	/client/proc/regenerate_mine,
+	/client/proc/database_status,
+	/client/proc/database_reconect,
+	/client/proc/remove_character,
+	/client/proc/clear_named_character_from_limbo,
+)
+
 /client/proc/save_server()
 	set category = "Server"
 	set desc="Forces a save of the server."
@@ -49,3 +59,74 @@
 	if(!check_rights(R_ADMIN))
 		return
 	SQLS_Force_Reconnect()
+
+//////////////////////////////////////////////////////////////////////
+// Limbo Character Verbs
+//////////////////////////////////////////////////////////////////////
+/client/proc/clear_named_character_from_limbo()
+	set category = "Server"
+	set desc = "Force delete from the database the limbo mob for a given character real_name. Meant to be used to clear character names being in-use even if there isn't an active character tied to it."
+	set name = "Delete Limbo Character"
+	if(!check_rights(R_ADMIN))
+		return
+	
+	var/choice = alert(usr, 
+		"USE WITH CAUTION! Will delete the limbo character entry in the database, so the associated name can be used by a new character. THIS WILL PERMENANTLY DELETE ANY CRYOED CHARACTER WITH THE GIVEN NAME IF THERE WAS ANY. Use only in last resort.", 
+		"Delete named character", 
+		"Proceed", 
+		"Cancel")
+	if(choice == "Cancel")
+		to_chat(usr, SPAN_INFO("Action Aborted"))
+		return
+
+	var/char_name  = sanitize_name(input(usr, "Enter character's name:", "Delete Limbo Character") as null|text, MAX_DESC_LEN, TRUE, FALSE)
+	if(!length(char_name))
+		to_chat(usr, SPAN_INFO("Action Aborted"))
+		return
+	var/query_text = "FROM `[SQLS_TABLE_LIMBO]` WHERE `metadata2` = '[char_name]'"
+
+	//Setup connection
+	var/should_close_connection = !check_save_db_connection()
+	establish_save_db_connection()
+
+	//First check what we'll delete
+	var/DBQuery/charcheck = dbcon_save.NewQuery("SELECT * [query_text]")
+	SQLS_EXECUTE_AND_REPORT_ERROR(charcheck, "USER LOOKING UP LIMBO CHARACTER FAILED:")
+	var/list/entries
+	while(charcheck.NextRow())
+		var/list/row = charcheck.GetRowData()
+		if(length(row))
+			LAZYADD(entries, "name:'[row["metadata2"]]' ckey:'[row["metadata"]]' pid:'[row["p_ids"]]'")
+	
+	if(!length(entries))
+		to_chat(usr, SPAN_WARNING("No matching characters found in the database. Aborting."))
+		if(should_close_connection)
+			close_save_db_connection()
+		return 
+	to_chat(usr, SPAN_INFO("The command will delete the following:\n[jointext(entries,"\n")]"))
+
+	//Ask again
+	choice = alert(usr, 
+		"Really delete [length(entries)] character\s from the database?", 
+		"Delete named character", 
+		"Cancel", 
+		"Ok")
+	if(choice == "Cancel")
+		to_chat(usr, SPAN_INFO("Action Aborted"))
+		if(should_close_connection)
+			close_save_db_connection()
+		return 
+
+	//Do the deleting
+	var/DBQuery/charrem = dbcon_save.NewQuery("DELETE [query_text]")
+	try
+		SQLS_EXECUTE_AND_REPORT_ERROR(charrem, "USER REMOVING LIMBO CHARACTER FAILED:")
+	catch(var/exception/E)
+		to_chat(usr, SPAN_DANGER("There was an error with the SQL query: [E]"))
+		if(should_close_connection)
+			close_save_db_connection()
+		throw E
+
+	if(should_close_connection)
+		close_save_db_connection()
+	to_chat(usr, SPAN_INFO("Successfully deleted all entries for [char_name]!"))

--- a/mods/persistence/modules/admin/verbs/admin.dm
+++ b/mods/persistence/modules/admin/verbs/admin.dm
@@ -93,10 +93,12 @@ var/global/list/persistence_admin_verbs = list(
 	var/DBQuery/charcheck = dbcon_save.NewQuery("SELECT * [query_text]")
 	SQLS_EXECUTE_AND_REPORT_ERROR(charcheck, "USER LOOKING UP LIMBO CHARACTER FAILED:")
 	var/list/entries
+	var/list/mind_ids
 	while(charcheck.NextRow())
 		var/list/row = charcheck.GetRowData()
 		if(length(row))
 			LAZYADD(entries, "name:'[row["metadata2"]]' ckey:'[row["metadata"]]' pid:'[row["p_ids"]]'")
+			LAZYADD(mind_ids, row["key"])
 	
 	if(!length(entries))
 		to_chat(usr, SPAN_WARNING("No matching characters found in the database. Aborting."))
@@ -118,14 +120,8 @@ var/global/list/persistence_admin_verbs = list(
 		return 
 
 	//Do the deleting
-	var/DBQuery/charrem = dbcon_save.NewQuery("DELETE [query_text]")
-	try
-		SQLS_EXECUTE_AND_REPORT_ERROR(charrem, "USER REMOVING LIMBO CHARACTER FAILED:")
-	catch(var/exception/E)
-		to_chat(usr, SPAN_DANGER("There was an error with the SQL query: [E]"))
-		if(should_close_connection)
-			close_save_db_connection()
-		throw E
+	for(var/mindid in mind_ids)
+		SSpersistence.one_off.RemoveFromLimbo(mindid, LIMBO_MIND)
 
 	if(should_close_connection)
 		close_save_db_connection()


### PR DESCRIPTION
## Description of changes
* Added "Delete Limbo Character" verb to get rid of bad limbo table character entries, to free up their character name for use again.
* Made save system text purple to distinguish it from all the other red text messages

## Changelog
:cl:
tweak: Save system progress messages are now displayed in purple in the chat so they can be told apart from other progress messages.
admin: Added "Delete Limbo Character" verb to get rid of bad limbo table character entries, to free up their character name for use again.
/:cl: