### PR TITLE
Smes reload properly

### DIFF
--- a/mods/persistence/game/machinery/_machines_base/stock_parts/_stock_parts.dm
+++ b/mods/persistence/game/machinery/_machines_base/stock_parts/_stock_parts.dm
@@ -1,14 +1,3 @@
-/obj/item/stock_parts/Initialize(ml, material_key)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/item/stock_parts/LateInitialize()
-	. = ..()
-	if(persistent_id && istype(loc, /obj/machinery))
-		var/obj/machinery/M = loc
-		if(!(src in M.component_parts))
-			M.install_component(src, FALSE, TRUE)
-
 /obj/item/stock_parts/on_install(obj/machinery/machine)
 	. = ..()
 	var/datum/extension/specification_holder/spec_holder = get_extension(src, /datum/extension/specification_holder)
@@ -22,5 +11,3 @@
 	if(spec_holder && spec_holder.is_processing)
 		if(!spec_holder.auto_process)
 			STOP_PROCESSING(SSspecifications, spec_holder)
-
-	

--- a/mods/persistence/game/machinery/machinery.dm
+++ b/mods/persistence/game/machinery/machinery.dm
@@ -1,19 +1,29 @@
-/obj/machinery/Initialize()
-	// Initialize expects that construct_state will be a path.
-	if(istype(construct_state))
-		construct_state = construct_state.type
-	. = ..()
-
-/obj/machinery/populate_parts(full_populate)
-	if(persistent_id) // Only objects that have been loaded with have this var set at creation, so we prevent recreating additional components.
-		return
-	. = ..()
-
 /obj/machinery/before_save()
+	. = ..()
+	CUSTOM_SV("old_component_parts", component_parts)
+
+/obj/machinery/after_deserialize()
 	. = ..()
 	initial_access = list() // Remove initial_access so that access isn't wiped on load.
 
+/obj/machinery/Initialize(mapload, d = 0, populate_parts = TRUE)
+	// Initialize expects that construct_state will be a path.
+	if(istype(construct_state))
+		construct_state = construct_state.type
+	. = ..(mapload, d, persistent_id? FALSE : populate_parts) //Don't populate when loading from save
+	if(persistent_id)
+		var/list/old_cpart = LOAD_CUSTOM_SV("old_component_parts")
+		if(length(old_cpart))
+			for(var/obj/item/stock_parts/P in old_cpart)
+				if(!(P in component_parts))
+					install_component(P, FALSE, FALSE)
+			RefreshParts()
+		CLEAR_SV("old_component_parts")
 
+// /obj/machinery/populate_parts(full_populate)
+// 	if(persistent_id) // Only objects that have been loaded with have this var set at creation, so we prevent recreating additional components.
+// 		return
+// 	. = ..()
 
 SAVED_VAR(/obj/machinery, stat)
 SAVED_VAR(/obj/machinery, emagged)
@@ -74,3 +84,10 @@ SAVED_VAR(/obj/item/stock_parts/power/terminal, terminal)
 SAVED_VAR(/obj/item/stock_parts/power/terminal, terminal_dir)
 
 SAVED_VAR(/obj/item/stock_parts/computer/charge_stick_slot,  stored_stick)
+
+
+//MISC
+/obj/structure/crematorium_tray
+	should_save = FALSE
+/obj/structure/morgue_tray
+	should_save = FALSE

--- a/mods/persistence/modules/power/smes.dm
+++ b/mods/persistence/modules/power/smes.dm
@@ -1,7 +1,25 @@
-/obj/machinery/power/smes/populate_parts(full_populate)
+/obj/machinery/power/smes/Initialize(ml)
 	if(persistent_id)
-		return
-	return ..()
+		CUSTOM_SV_LIST(\
+		"last_charge"         = charge,\
+		"last_input_level"    = input_level,\
+		"last_output_level"   = output_level,\
+		"last_output_attempt" = output_attempt,\
+		"last_input_attempt"  = input_attempt,\
+		)
+	. = ..()
+	if(persistent_id)
+		charge         = LOAD_CUSTOM_SV("last_charge")
+		input_level    = LOAD_CUSTOM_SV("last_input_level")
+		output_level   = LOAD_CUSTOM_SV("last_output_level")
+		output_attempt = LOAD_CUSTOM_SV("last_output_attempt")
+		input_attempt  = LOAD_CUSTOM_SV("last_input_attempt")
+		CLEAR_SV("last_charge")
+		CLEAR_SV("last_input_level")
+		CLEAR_SV("last_output_level")
+		CLEAR_SV("last_output_attempt")
+		CLEAR_SV("last_input_attempt")
+	update_icon()
 
 //Saved Variables Define
 SAVED_VAR(/obj/machinery/power/smes/batteryrack, mode)


### PR DESCRIPTION
## Description of changes
* Made machines save their old components list.
* Now install all loaded components without calling RefreshPart until all parts are installed, which prevent the issue the smes was experiencing on load.
* Populate parts is now overriden from the arg passed to Initialize, so you don't need to override populate parts for every single machines.

## Changelog
:cl:
fix: SMES now keep the state they had when saved on save load.
fix: Machinery now reinstall its old components instead of guessing what was actually installed. 
fix: stock_parts no longer in charge of reinstalling themselves.
/:cl: