### PR TITLE
Additional debug info on limbo fails

### DIFF
--- a/mods/persistence/game/machinery/cryopod.dm
+++ b/mods/persistence/game/machinery/cryopod.dm
@@ -134,8 +134,8 @@
 		if(occupant_mind)
 			var/success = SSpersistence.AddToLimbo(list(occupant, occupant_mind), occupant_mind.unique_id, LIMBO_MIND, occupant_mind.key, occupant_mind.current.real_name, TRUE)
 			if(!success)
-				to_chat(occupant, SPAN_WARNING("Something has gone wrong while deserializing your character. Contact an admin!"))
 				log_and_message_admins("\The cryopod at ([x], [y], [z]) failed to despawn the occupant [occupant]!")
+				to_chat(occupant, SPAN_WARNING("Something has gone wrong while saving your character. Contact an admin!"))
 				audible_message("\The [src] emits a series of warning tones!")
 				return // We don't set despawning here in order to keep the mob safe without continuously retrying despawns.
 			QDEL_NULL(occupant.mind)

--- a/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
@@ -33,8 +33,13 @@
 
 		if(length(element_inserts) > 0) 
 			tot_element_inserts += length(element_inserts)
-			query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIMBO_LIST_ELEM]`(`list_id`,`key`,`key_type`,`value`,`value_type`,`limbo_assoc`) VALUES["(" + jointext(element_inserts, ",'[limbo_assoc]'),(") + ",'[limbo_assoc]')"]")
-			SQLS_EXECUTE_AND_REPORT_ERROR(query, "LIMBO ELEMENT SERIALIZATION FAILED:")
+			var/raw_statement = "INSERT INTO `[SQLS_TABLE_LIMBO_LIST_ELEM]`(`list_id`,`key`,`key_type`,`value`,`value_type`,`limbo_assoc`) VALUES["(" + jointext(element_inserts, ",'[limbo_assoc]'),(") + ",'[limbo_assoc]')"]"
+			query = dbcon_save.NewQuery(raw_statement)
+			try
+				SQLS_EXECUTE_AND_REPORT_ERROR(query, "LIMBO ELEMENT SERIALIZATION FAILED:")
+			catch(var/exception/E)
+				log_warning("Caught exception when issuing query :\n[raw_statement]")
+				throw E
 
 	catch (var/exception/e)
 		if(istype(e, /exception/sql_connection))


### PR DESCRIPTION
## Description of changes
Log the query on limbo add failure.

## Changelog
:cl:
server:  Now logs the failed query when limbo save fails.
/:cl:
