### PR TITLE
Prevent food reagents from resetting their reagents on load

### DIFF
--- a/mods/persistence/modules/reagents/reagent_containers/food/food.dm
+++ b/mods/persistence/modules/reagents/reagent_containers/food/food.dm
@@ -1,3 +1,11 @@
+/obj/item/chems/food/Initialize(ml, material_key)
+	var/old_nutri_amt = nutriment_amt
+	if(persistent_id)
+		nutriment_amt = 0 //If we loaded, prevent the init code from creating the reagents again.
+	. = ..()
+	if(old_nutri_amt)
+		nutriment_amt = old_nutri_amt
+	
 SAVED_VAR(/obj/item/grown, plantname)
 SAVED_VAR(/obj/item/grown, potency)
 


### PR DESCRIPTION
## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Food items shouldn't magically get refilled on saved load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->