### PR TITLE
Grown food bugfix

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -54,6 +54,7 @@
 	update_desc()
 	if(reagents.total_volume > 0)
 		bitesize = 1+round(reagents.total_volume / 2, 1)
+		amount_per_transfer_from_this = bitesize
 
 /obj/item/chems/food/grown/proc/update_desc()
 	set waitfor = FALSE


### PR DESCRIPTION
## Description of changes
Make sure the amount_per_transfer_from_this is updated
Grown food has to update the amount_per_transfer_from_this var after it modifies the bitesize var for the generic feeding code to work properly.

This ideally would go upstream, but since loaf is on a hiatus I'll submit it down here first.

## Changelog
:cl:
bugfix: Fix bitesize not matching amount_per_transfer_from_this  after its changed by the grown item code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->