### PR TITLE
Fixes some July 23rd issues

### DIFF
--- a/mods/persistence/modules/modular_computers/file_system/programs/cloning.dm
+++ b/mods/persistence/modules/modular_computers/file_system/programs/cloning.dm
@@ -100,7 +100,7 @@
 		return
 
 	if(href_list["change_file_server"])
-		var/list/file_servers = network.get_file_server_tags(MF_ROLE_CLONING, user)
+		var/list/file_servers = network.get_file_server_tags(MF_ROLE_CLONING, computer.get_access(user))
 		var/file_server = input(usr, "Choose a fileserver to view files on:", "Select File Server") as null|anything in file_servers
 		if(file_server)
 			current_filesource.server = file_server

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -283,7 +283,7 @@ var/global/list/serialization_time_spent_type
 			KT = SERIALIZER_TYPE_NUM
 		else if (istext(key))
 			KT = SERIALIZER_TYPE_TEXT
-			key = byond2utf8(key)
+			KV = byond2utf8(key)
 		else if (ispath(key) || IS_PROC(key))
 			KT = SERIALIZER_TYPE_PATH
 		else if (isfile(key))


### PR DESCRIPTION
## Description of changes
Fixes a couple bugs discovered last week, one of them critical
* Fixed a bug where list were not properly sanitizing ``\improper`` from their keys, causing saving crashes
* Fixed a bug where the cloning program could not select mainframes

## Changelog
:cl:
fix: The cloning program can once again select remote mainframes
/:cl: