### PR TITLE
July 30 Persistence fixes

### DIFF
--- a/maps/kleibkhar/kleibkhar_turf.dm
+++ b/maps/kleibkhar/kleibkhar_turf.dm
@@ -14,7 +14,9 @@
 	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors["[z]"]
 	if(istype(E) && E.grass_color)
 		color = E.grass_color
-	if(!persistent_id)
+	
+	// Turfs don't retain persistent IDs across load currently, so we just check if we're in a loaded world instead.
+	if(!SSpersistence.in_loaded_world)
 		generate_tile_prop()
 
 /turf/exterior/kleibkhar_grass/proc/generate_tile_prop()

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -116,6 +116,7 @@
 #include "modules\clothing\under\accessories\storage.dm"
 #include "modules\detectivework\forensics_designs.dm"
 #include "modules\detectivework\evidence\_evidence_holder.dm"
+#include "modules\detectivework\evidence\_evidence_type.dm"
 #include "modules\detectivework\microscope\_forensic_machine.dm"
 #include "modules\economy\economy.dm"
 #include "modules\emotes\audible.dm"

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -42,6 +42,7 @@
 #include "datums\wires\wires.dm"
 #include "game\antagonist\antagonist_helpers.dm"
 #include "game\area\areas.dm"
+#include "game\area\area_space.dm"
 #include "game\gamemodes\persistence.dm"
 #include "game\machinery\cryopod.dm"
 #include "game\machinery\machinery.dm"

--- a/mods/persistence/controllers/subsystems/autosave.dm
+++ b/mods/persistence/controllers/subsystems/autosave.dm
@@ -1,56 +1,67 @@
 SUBSYSTEM_DEF(autosave)
 	name = "Autosave"
-	wait = 60 MINUTES
-	next_fire = 60 MINUTES	// To prevent saving upon start.
+	wait = 1 MINUTE
 	runlevels = RUNLEVEL_GAME
 
 	var/saves = 0 // Number of times we've autosaved.
 	var/saving = 0 // Whether or not we are saving right now.
 	var/announced = 0 // Whether or not we've announced we're about to save.
 
+	var/last_save			// world.time of the last save
+	var/autosave_interval	// Time between autosaves.
+
 /datum/controller/subsystem/autosave/Initialize()
 	. = ..()
-	wait = config.autosave_interval MINUTES
-	next_fire = config.autosave_interval MINUTES	// To prevent saving upon start.
+	last_save = world.time
+	autosave_interval = config.autosave_interval	// To prevent saving upon start.
 
 /datum/controller/subsystem/autosave/stat_entry()
-	..(saving ? "Currently Saving" : "Next autosave in [round((next_fire - world.time) / (1 MINUTE), 0.1)] minutes.")
+	..(saving ? "Currently Saving" : "Next autosave in [round((last_save + autosave_interval - world.time) / (1 MINUTE), 0.1)] minutes.")
 
 /datum/controller/subsystem/autosave/fire()
-	Save()
+	AnnounceSave()
+	if(last_save + autosave_interval <= world.time)
+		Save()
 
-/datum/controller/subsystem/autosave/proc/Save()
+/datum/controller/subsystem/autosave/proc/Save(var/check_for_restart = TRUE)
 	if(saving)
 		message_admins(SPAN_DANGER("Attempted to save while already saving!"))
 	else
 		saves += 1
-		var/reset_after_save = config.autosave_auto_reset > 0 && saves >= config.autosave_auto_reset
 		to_world("<font size=4 color='green'>Beginning save! Server will unpause when save is complete.</font>")
-		if(reset_after_save)
+		
+		var/reset_after_save = config.autosave_auto_reset > 0 && world.time >= config.autosave_auto_reset
+
+		if(check_for_restart && reset_after_save)
 			to_world("<font size=4 color='red'>Server is resetting after this save!</font>")
-		sleep(20)
 
 		saving = 1
 		for(var/datum/controller/subsystem/S in Master.subsystems)
 			S.disable()
-		SSmapping.Save()
+		SSpersistence.SaveWorld()
 		for(var/datum/controller/subsystem/S in Master.subsystems)
 			S.enable()
 		saving = 0
 		to_world("<font size=4 color='green'>World save complete!</font>")
 
-		if(reset_after_save)
+		if(check_for_restart && reset_after_save)
 			to_world("<font size=4 color='red'>Server is going down NOW!</font>")
 			world.Reboot()
+		
+		last_save = world.time
 
 /datum/controller/subsystem/autosave/proc/AnnounceSave()
-	var/minutes = (next_fire - world.time) / (1 MINUTE)
+	var/minutes = (last_save + autosave_interval - world.time) / (1 MINUTE)
 
 	if(!announced && minutes <= 5)
-		to_world("<font size=4 color='green'>Autosave in 5 Minutes!</font>")
+		to_world("<font size=4 color='green'>Autosave in 5 minutes!</font>")
+		if((world.time + minutes MINUTES) >= config.autosave_auto_reset)
+			to_world("<font size=4 color='green'>The server will reboot after this save!</font>")
 		announced = 1
 	if(announced == 1 && minutes <= 1)
-		to_world("<font size=4 color='green'>Autosave in 1 Minute!</font>")
+		to_world("<font size=4 color='green'>Autosave in 1 minute!</font>")
+		if((world.time + minutes MINUTES) >= config.autosave_auto_reset)
+			to_world("<font size=4 color='green'>The server will reboot after this save!</font>")
 		announced = 2
 	if(announced == 2 && minutes >= 6)
 		announced = 0

--- a/mods/persistence/controllers/subsystems/mining.dm
+++ b/mods/persistence/controllers/subsystems/mining.dm
@@ -42,8 +42,8 @@
 SUBSYSTEM_DEF(mining)
 	name = "Mining"
 	wait = 1 MINUTES
-	next_fire = 1 MINUTES	// To prevent saving upon start.
-	init_order = SS_INIT_MAPPING - 1
+	next_fire = 1 MINUTES
+	init_order = SS_INIT_DEFAULT
 	runlevels = RUNLEVEL_GAME
 
 	var/regen_interval = 270	// How often in minutes to generate mining levels.

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -214,12 +214,14 @@
 					else
 						area_turf_count++
 
-					// This if statement, while complex, checks to see if we should save this turf.
-					// Turfs not saved become their default_turf after deserialization.
-					if(!istype(T) || !LAZYLEN(T.contents))
-						continue
+					// These if statements checks to see if we should save this turf.
+
 					//Ignore non-saved areas
 					if(istype(TA) && (TA.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
+						continue
+					
+					// Turfs not saved become their default_turf after deserialization.
+					if(!istype(T) || !LAZYLEN(T.contents))
 						continue
 					
 					//Save anything else

--- a/mods/persistence/game/area/area_space.dm
+++ b/mods/persistence/game/area/area_space.dm
@@ -1,0 +1,2 @@
+/area/space
+	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_BACKGROUND

--- a/mods/persistence/game/area/area_space.dm
+++ b/mods/persistence/game/area/area_space.dm
@@ -1,2 +1,3 @@
-/area/space
-	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_BACKGROUND
+/area/space/Initialize()
+	area_flags &= ~AREA_FLAG_IS_NOT_PERSISTENT
+	. = ..()

--- a/mods/persistence/modules/admin/verbs/admin.dm
+++ b/mods/persistence/modules/admin/verbs/admin.dm
@@ -16,7 +16,7 @@ var/global/list/persistence_admin_verbs = list(
 
 	if(!check_rights(R_ADMIN))
 		return
-	SSautosave.Save()
+	SSautosave.Save(FALSE)
 
 /client/proc/regenerate_mine()
 	set category = "Admin"

--- a/mods/persistence/modules/detectivework/evidence/_evidence_type.dm
+++ b/mods/persistence/modules/detectivework/evidence/_evidence_type.dm
@@ -1,0 +1,2 @@
+SAVED_FLATTEN(/datum/forensics)
+SAVED_FLATTEN(/datum/fingerprint)

--- a/mods/persistence/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/mods/persistence/modules/modular_computers/networking/device_types/_network_device.dm
@@ -1,3 +1,6 @@
+/datum/extension/network_device
+	should_save = TRUE
+
 // Placeholder fix for refreshing fabricator design cache until fabricator UI rework is done upstream etc.
 /datum/extension/network_device/Topic(href, href_list)
 	. = ..()
@@ -9,3 +12,8 @@
 	if(href_list["refresh_machine"])
 		holder?.handle_post_network_connection()
 		return TOPIC_REFRESH
+
+SAVED_VAR(/datum/extension/network_device, network_id)
+SAVED_VAR(/datum/extension/network_device, key)
+SAVED_VAR(/datum/extension/network_device, command_and_call)
+SAVED_VAR(/datum/extension/network_device, command_and_write)

--- a/mods/persistence/modules/overmap/overmap_shuttle.dm
+++ b/mods/persistence/modules/overmap/overmap_shuttle.dm
@@ -1,3 +1,6 @@
+/datum/shuttle/autodock/overmap
+	landing_skill_needed = SKILL_ADEPT // All landing in Persistence depends on free landing, so tune this down a bit.
+
 /datum/shuttle/autodock/overmap/after_deserialize()
 	. = ..()
 	refresh_fuel_ports_list()

--- a/mods/persistence/modules/shuttles/landmarks.dm
+++ b/mods/persistence/modules/shuttles/landmarks.dm
@@ -1,3 +1,7 @@
 /obj/effect/shuttle_landmark/Initialize()
+	// Don't autoset your base_area and base_turf if loaded.
+	if(persistent_id)
+		flags &= ~SLANDMARK_FLAG_AUTOSET
+	
 	name = initial(name) // Landmarks set their names automatically, so the saved name needs to be removed.
 	. = ..()

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -602,6 +602,8 @@ var/global/list/serialization_time_spent_type
 	SQLS_EXECUTE_AND_REPORT_ERROR(query, "UNABLE TO WIPE PREVIOUS SAVE:")
 	query = dbcon_save.NewQuery("TRUNCATE TABLE `[SQLS_TABLE_Z_LEVELS]`;")
 	SQLS_EXECUTE_AND_REPORT_ERROR(query, "UNABLE TO WIPE PREVIOUS SAVE:")
+	query = dbcon_save.NewQuery("TRUNCATE TABLE `[SQLS_TABLE_AREAS]`;")
+	SQLS_EXECUTE_AND_REPORT_ERROR(query, "UNABLE TO WIPE PREVIOUS SAVE:")
 	Clear()
 
 /serializer/sql/save_exists()


### PR DESCRIPTION
## Description of changes
Various downstream fixes encountered on July 30th
* Network devices now save and connect to their networks on load. This has some overhead, but it's basically necessary.
* Optimizes forensics saving by flattening evidence datums. Initial tests have shown this seems to work fine, especially as forensics evidence does not contain any references to other datums, generally.
* Fixes saved area saving, previously broken by the database not being wiped pre-save
* Fixes space being set as non-persistent, which was causing sectors to not save properly.
* Fixes shuttle landmarks setting their base areas and turfs incorrectly on load
* Fixes mining generation generating far too early and finding the incorrect strata.
* Fixes autosaving, currently set to autosave on the hour and restart the server every 12 hours.

## Authorship
Myself