### PR TITLE
Fix verb to auto kick players and lock server

### DIFF
--- a/mods/persistence/modules/admin/verbs/admin.dm
+++ b/mods/persistence/modules/admin/verbs/admin.dm
@@ -77,7 +77,7 @@ var/global/list/persistence_admin_verbs = list(
 
 	var/nb_kicked = 0
 	for(var/datum/mind/M in global.player_minds)
-		if(check_rights(R_ADMIN, TRUE, M.get_client()))
+		if(check_rights(R_ADMIN, FALSE, M.current?.get_client()))
 			continue
 		//Kick them to lobby, unless they already are, or are observing
 		if(M.current && istype(M.current, /mob/living))


### PR DESCRIPTION
## Description of changes
The get_client() proc on mind was inexplicably left stubbed out. So got the actual client another way. 

## Changelog
:cl:
admin: Fixed "Lock Server and Kick Players" verb not kicking players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->