### PR TITLE
Add rng trees and plant distribution

### DIFF
--- a/maps/kleibkhar/kleibkhar_turf.dm
+++ b/maps/kleibkhar/kleibkhar_turf.dm
@@ -63,14 +63,15 @@ var/global/list/grass_seed_drop_types_uncommon = list(
 		generate_tile_prop()
 
 /turf/exterior/kleibkhar_grass/proc/generate_tile_prop()
-	if(rand(0, KLEIBKHAR_VEGETATION_CHANCE) != KLEIBKHAR_VEGETATION_CHANCE)
+	if(rand(0, KLEIBKHAR_VEGETATION_CHANCE) != KLEIBKHAR_VEGETATION_CHANCE || length(contents))
 		return //No vegetation/prop for this tile
 	
 	var/list/rnd = list(\
-		"plant"  = rand(0,  80),\
-		"rock"   = rand(0,  25),\
-		"dirt"   = rand(0,  50),\
-		"lichen" = rand(0,  80),\
+		"plant"     = rand(0,  80),\
+		"rock"      = rand(0,  25),\
+		"dirt"      = rand(0,  50),\
+		"lichen"    = rand(0,  80),\
+		"dead_tree" = rand(0,  25),\
 	)
 	sortTim(rnd, .proc/cmp_numeric_dsc, TRUE)
 
@@ -84,6 +85,8 @@ var/global/list/grass_seed_drop_types_uncommon = list(
 			prop = new /obj/effect/decal/cleanable/dirt(src)
 		if("lichen")
 			prop = new /obj/effect/decal/cleanable/lichen(src)
+		if("dead_tree")
+			prop = new /obj/structure/flora/tree/dead(src)
 	
 	prop.pixel_x += rand(-8, 8)
 	prop.pixel_y += rand(-8, 8)

--- a/maps/kleibkhar/kleibkhar_turf.dm
+++ b/maps/kleibkhar/kleibkhar_turf.dm
@@ -46,6 +46,30 @@ var/global/list/grass_seed_drop_types_uncommon = list(
 	"lavender",
 	"algae",
 )
+
+var/global/list/kleibkhar_possible_mushroom_seeds = list(
+	"mold",
+	"reishi",
+	"amanita",
+	"destroyingangel",
+	"libertycap",
+	"mushrooms",
+	"towercap",
+	"glowbell",
+	"plumphelmet",
+)
+
+var/global/list/kleibkhar_possible_tree_seeds = list(
+	"banana",
+	"apple",
+	"lime",
+	"lemon",
+	"orange",
+	"cocoa",
+	"cherry",
+	"bamboo",
+)
+
 /turf/exterior/kleibkhar_grass
 	name = "wild grass"
 	icon = 'icons/turf/exterior/wildgrass.dmi'
@@ -66,17 +90,21 @@ var/global/list/grass_seed_drop_types_uncommon = list(
 	if(rand(0, KLEIBKHAR_VEGETATION_CHANCE) != KLEIBKHAR_VEGETATION_CHANCE || length(contents))
 		return //No vegetation/prop for this tile
 	
-	var/list/rnd = list(\
-		"plant"     = rand(0,  80),\
-		"rock"      = rand(0,  25),\
-		"dirt"      = rand(0,  50),\
-		"lichen"    = rand(0,  80),\
-		"dead_tree" = rand(0,  25),\
-	)
-	sortTim(rnd, .proc/cmp_numeric_dsc, TRUE)
+	//Pick a prop/plant
+	var/picked = pick(
+			prob(60); "plant", 
+			prob(60); "lichen", 
+			prob(40); "dirt", 
+			prob(25); "rock",
+			prob(25); "dead_tree",
+			prob(3); "seed_tree",
+			prob(2); "seed_plant",
+			prob(1); "seed_mushroom"
+		)
 
+	//Handle props
 	var/obj/prop
-	switch(rnd[1])
+	switch(picked)
 		if("plant")
 			prop = new /obj/structure/flora/grass/green(src)
 		if("rock")
@@ -87,7 +115,21 @@ var/global/list/grass_seed_drop_types_uncommon = list(
 			prop = new /obj/effect/decal/cleanable/lichen(src)
 		if("dead_tree")
 			prop = new /obj/structure/flora/tree/dead(src)
+
+	//Handle seeds
+	if(!prop)
+		var/picked_seed
+		switch(picked)
+			if("seed_tree")
+				picked_seed = pick(global.kleibkhar_possible_tree_seeds)
+			if("seed_plant")
+				picked_seed = prob(80)? pick(global.grass_seed_drop_types_common) : pick(global.grass_seed_drop_types_uncommon)
+			if("seed_mushroom")
+				picked_seed = pick(global.kleibkhar_possible_mushroom_seeds)
+		if(picked_seed)
+			prop = new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(src, picked_seed, prob(50))
 	
+	//Add some randomness to the placement
 	prop.pixel_x += rand(-8, 8)
 	prop.pixel_y += rand(-8, 8)
 

--- a/mods/persistence/modules/hydroponics/trays.dm
+++ b/mods/persistence/modules/hydroponics/trays.dm
@@ -49,4 +49,4 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Initialize(mapload, datum/seed/newseed, start_mature)
 	if(istext(newseed))
 		newseed = SSplants.seeds[newseed]
-	. = ..(mapload, newseed, start_mature) // avoid passing newseed as dir
+	. = ..(mapload, newseed, start_mature)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Updates kleibkhar grass tufs to spawn trees.
* Added a check to make sure not to gen anything on a tile that got something already.
* Added 25% chances for a dead tree to spawn. Same chance as a rock.
* Added a tiny random chance to spawn hydroponic plants on the map.

Since we only got snow covered dead tree sprites I've had to use those.

## Changelog
:cl:
tweak: Kleibkhar grass turfs now may spawn dead trees.
tweak: Kleibkhar  grass turfs now may spawn plants from hydroponics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->