### PR TITLE
RND adjustments

### DIFF
--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -226,6 +226,7 @@
 #include "modules\reagents\reagent_containers\food\food.dm"
 #include "modules\science\_defines.dm"
 #include "modules\science\recipe.dm"
+#include "modules\science\research_overrides.dm"
 #include "modules\science\unfinished_assembly.dm"
 #include "modules\science\files\design.dm"
 #include "modules\science\files\writer.dm"

--- a/mods/persistence/controllers/subsystems/initialization/fabrication.dm
+++ b/mods/persistence/controllers/subsystems/initialization/fabrication.dm
@@ -12,7 +12,9 @@
 		research_recipes[fab_class] -= get_unlocked_recipes(fab_class, get_default_initial_tech_levels())
 		
 		for(var/datum/fabricator_recipe/recipe in research_recipes[fab_class])
-			if(TECH_ESOTERIC in recipe.required_technology) // These techs must be unlocked via random chance during iteration
+			if(recipe.research_excluded)
+				research_recipes[fab_class] -= recipe
+			else if(TECH_ESOTERIC in recipe.required_technology) // These techs must be unlocked via random chance during iteration
 				research_recipes[fab_class] -= recipe
 
 		if(!length(research_recipes[fab_class]))

--- a/mods/persistence/modules/science/recipe.dm
+++ b/mods/persistence/modules/science/recipe.dm
@@ -6,6 +6,8 @@
 
 	var/instability = 0
 
+	var/research_excluded = FALSE
+
 /datum/fabricator_recipe/build(turf/location, datum/fabricator_build_order/order)
 	if(length(finishing_requirements))
 		. = list()

--- a/mods/persistence/modules/science/research_overrides.dm
+++ b/mods/persistence/modules/science/research_overrides.dm
@@ -1,0 +1,19 @@
+// Overrides for the tech requirements of items and the exclusion of certain recipes
+
+/obj/item/stock_parts/circuitboard/router
+	origin_tech = "{'programming':1,'magnets':1}"
+
+/obj/item/stock_parts/circuitboard/mainframe
+	origin_tech = "{'programming':1}"
+
+/obj/item/stock_parts/subspace/filter
+	origin_tech = "{'programming':1,'magnets':1}"
+
+/datum/fabricator_recipe/imprinter/circuit/shuttle
+	research_excluded = TRUE
+
+/datum/fabricator_recipe/imprinter/ai
+	research_excluded = TRUE
+
+/datum/fabricator_recipe/imprinter/ai_core
+	research_excluded = TRUE


### PR DESCRIPTION
## Description of changes
Some QoL and backend changes to research
* Adds a method of removing research recipes from availability in the CAD program
* Reworks how listing recipes is done in the RnD UI. This is slightly less performant but much cleaner. The previous UI code was dropping recipes
* Design computer files will now include the name of the item in the file name
* Finishing a section of the design will now play a sound and instantly display the maximum number of specification options
*  The CAD program will now autoselect a design database if available, as this is the most likely desired file target

## Why and what will this PR improve
This is in response to some feedback received on the RnD system, as well as Gene's request to be able to remove certain designs from availability.

## Authorship
Myself

## Changelog
:cl:
tweak: The RnD program will now name files with the item's name
tweak: Concluding a section of research will now automatically remove all non-concluding theories from the design's options.
/:cl: