### PR TITLE
add more default blend objects

### DIFF
--- a/code/game/objects/structures/_structure_icon.dm
+++ b/code/game/objects/structures/_structure_icon.dm
@@ -1,4 +1,11 @@
-var/global/list/default_blend_objects = list(/obj/machinery/door, /turf/simulated/wall)
+var/global/list/default_blend_objects = list(
+	/obj/machinery/door,
+	/obj/structure/door,
+	/obj/structure/plasticflaps,
+	/turf/simulated/wall,
+	/turf/exterior/wall,
+	/turf/unsimulated/wall,
+)
 var/global/list/default_noblend_objects = list(/obj/machinery/door/window, /obj/machinery/door/firedoor, /obj/machinery/door/blast)
 
 /obj/structure


### PR DESCRIPTION
## Description of changes
Makes walls and structures blend with things that they really should blend with in order not to look stupid.