### PR TITLE
Make open blast door show open on map

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -332,6 +332,7 @@
 
 /obj/machinery/door/blast/regular/open
 	begins_closed = FALSE
+	icon_state = "pdoor0"
 
 // SUBTYPE: Shutters
 // Nicer looking, and also weaker, shutters. Found in kitchen and similar areas.


### PR DESCRIPTION
## Description of changes
The open blast door variant would show as closed in the mapping tool. So fixed that.
