### PR TITLE
Injector on variant has on icon in maptool

### DIFF
--- a/mods/persistence/modules/atmospherics/components/injector.dm
+++ b/mods/persistence/modules/atmospherics/components/injector.dm
@@ -15,4 +15,5 @@
 	queue_icon_update()
 
 /obj/machinery/atmospherics/unary/outlet_injector/cabled/on
+	icon_state = "on"
 	use_power = POWER_USE_IDLE


### PR DESCRIPTION
## Description of changes
The thing didn't have the right icon in the mapping tool
