### PR TITLE
Fix missing overmap event mapper icon

### DIFF
--- a/mods/persistence/modules/overmap/events/event.dm
+++ b/mods/persistence/modules/overmap/events/event.dm
@@ -41,6 +41,8 @@
 
 	var/effect_count
 	var/effects_to_spawn
+	icon = 'icons/obj/overmap.dmi'
+	icon_state = "object"
 
 /obj/effect/overmap/overmap_effect_spawner/Initialize()
 	. = ..()


### PR DESCRIPTION
## Description of changes
The event was invisible on the map editor.
