### PR TITLE
Internet uplink fix

### DIFF
--- a/code/modules/overmap/internet/internet_circuitboards.dm
+++ b/code/modules/overmap/internet/internet_circuitboards.dm
@@ -8,11 +8,6 @@
 		/obj/item/stock_parts/micro_laser = 2,
 		/obj/item/stock_parts/smes_coil = 1
 	)
-	additional_spawn_components = list(
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/terminal = 1
-	)
 
 /obj/item/stock_parts/circuitboard/internet_uplink_computer
 	name = "circuitboard (PLEXUS uplink controller)"

--- a/code/modules/overmap/internet/internet_uplink.dm
+++ b/code/modules/overmap/internet/internet_uplink.dm
@@ -8,7 +8,6 @@ var/global/list/internet_uplinks = list()
 	icon_state = "unpowered"
 	density = 1
 	anchored = 1
-	stat_immune = 0
 
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal)


### PR DESCRIPTION
## Description of changes
Prevented the internet uplink from spawning with a keyboard and screen parts it doesn't need or uses. 
