### PR TITLE
Fixed some godmode oversights

### DIFF
--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -72,7 +72,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 	if(vsc.contaminant_control.CLOTH_CONTAMINATION) contaminate()
 
 	//Anything else requires them to not be dead.
-	if(stat >= 2)
+	if(stat >= 2 || status_flags & GODMODE)
 		return
 
 	//Burn skin if exposed.

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -638,6 +638,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	holder.remove_reagent(type, removed)
 
 /decl/material/proc/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
+	if(M.status_flags & GODMODE)
+		return
+
 	if(radioactivity)
 		M.apply_damage(radioactivity * removed, IRRADIATE, armor_pen = 100)
 
@@ -747,7 +750,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 					if(!screamed && affecting.can_feel_pain())
 						screamed = TRUE
 						H.emote("scream")
-					affecting.status |= ORGAN_DISFIGURED
+					affecting.status |= ORGAN_DISFIGURED //#FIXME: That probably should be decided by the organ based on the amount of damage or something??
 
 		if(!M.unacidable)
 			M.take_organ_damage(0, min(removed * solvent_power * ((removed < solvent_melt_dose) ? 0.1 : 0.2), solvent_max_damage), override_droplimb = DISMEMBER_METHOD_ACID)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -446,6 +446,8 @@ var/global/list/ailment_reference_cache = list()
 
 /obj/item/organ/proc/get_possible_ailments()
 	. = list()
+	if(owner.status_flags & GODMODE)
+		return .
 	for(var/ailment_type in subtypesof(/datum/ailment))
 		var/datum/ailment/ailment = ailment_type
 		if(initial(ailment.category) == ailment_type)


### PR DESCRIPTION
## Description of changes
* Prevent air contaminants from damaging a mob with godmode on.
* Prevent ailments from appearing on the organs of a godmode mob.
* Prevented blood effects from chems on godmode mobs.
