### PR TITLE
Make posters available in mapping tool

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -87,12 +87,6 @@
 	var/poster_type
 	var/ruined = 0
 
-/obj/structure/sign/poster/bay_9
-	poster_type = /decl/poster/bay_9
-
-/obj/structure/sign/poster/bay_50
-	poster_type = /decl/poster/bay_50
-
 /obj/structure/sign/poster/Initialize(var/ml, var/_mat, var/_reinf_mat, var/placement_dir = null, var/give_poster_type = null)
 	. = ..(ml, _mat, _reinf_mat)
 	if(!poster_type)

--- a/code/game/objects/effects/decals/posters/bs12.dm
+++ b/code/game/objects/effects/decals/posters/bs12.dm
@@ -1,290 +1,67 @@
+/**Define a poster's decl and its mapper type */
+#define DEFINE_POSTER(TYPENAME, ICONSTATE, NAME, DESC)\
+/decl/poster/##TYPENAME{name = NAME; desc = DESC; icon_state = ICONSTATE;};\
+/obj/structure/sign/poster/##TYPENAME{poster_type = /decl/poster/##TYPENAME; name = NAME; icon_state = ICONSTATE;};
+
 // baystation12 posters
-/decl/poster/bay_1
-	icon_state="bsposter1"
-	name = "Unlucky Space Explorer"
-	desc = "This particular one depicts a skeletal form within a space suit."
+DEFINE_POSTER(bay_1,  "bsposter1",  "Unlucky Space Explorer",                          "This particular one depicts a skeletal form within a space suit.")
+DEFINE_POSTER(bay_2,  "bsposter2",  "Positronic Logic Conflicts",                      "This particular one depicts the cold, unmoving stare of a particular advanced AI.")
+DEFINE_POSTER(bay_3,  "bsposter3",  "Paranoia",                                        "This particular one warns of the dangers of trusting your co-workers too much.")
+DEFINE_POSTER(bay_4,  "bsposter4",  "Keep Calm",                                       "This particular one is of a famous New Earth design, although a bit modified. Someone has scribbled an O over the A on the poster.")
+DEFINE_POSTER(bay_5,  "bsposter5",  "Martian Warlord",                                 "This particular one depicts the cartoony mug of a certain Martial Warmonger.")
+DEFINE_POSTER(bay_6,  "bsposter6",  "Technological Singularity",                       "This particular one is of the blood-curdling symbol of a long-since defeated enemy of humanity.")
+DEFINE_POSTER(bay_7,  "bsposter7",  "Wasteland",                                       "This particular one is of a couple of ragged gunmen, one male and one female, on top of a mound of rubble. The number \"12\" is visible on their blue jumpsuits.")
+DEFINE_POSTER(bay_8,  "bsposter8",  "Pinup Girl Cindy",                                "This particular one is of a historical corporate PR girl, Cindy, in a particularly feminine pose.")
+DEFINE_POSTER(bay_9,  "bsposter9",  "Pinup Girl Amy",                                  "This particular one is of Amy, the nymphomaniac urban legend of deep space. How this photograph came to be is not known.")
+DEFINE_POSTER(bay_10, "bsposter10", "Don't Panic",                                     "This particular one depicts some sort of star in a grimace. The \"Don't Panic\" is written in big, friendly letters.")
+DEFINE_POSTER(bay_11, "bsposter11", "Underwater Laboratory",                           "This particular one is of the fabled last crew of a previous Company project.")
+DEFINE_POSTER(bay_12, "bsposter12", "Rogue AI",                                        "This particular one depicts the shell of the infamous AI that catastropically comandeered one of humanity's earliest space stations. Back then, the Company was just known as TriOptimum.")
+DEFINE_POSTER(bay_13, "bsposter13", "User of the Arcane Arts",                         "This particular one depicts a wizard, casting a spell. You can't really make out if it's an actual photograph or a computer-generated image.")
+DEFINE_POSTER(bay_14, "bsposter14", "Levitating Skull",                                "This particular one is the portrait of a flying enchanted skull. Its adventures along with its fabled companion are now fading through history...")
+DEFINE_POSTER(bay_15, "bsposter15", "Augmented Legend",                                "This particular one is of an obviously augmented individual, gazing towards the sky. The cyber-city in the backround is rather punkish.")
+DEFINE_POSTER(bay_16, "bsposter16", "Dangerous Static",                                "This particular one depicts nothing remarkable other than a rather mesmerising pattern of monitor static. There's a tag on the sides of the poster, but it's ripped off.")
+DEFINE_POSTER(bay_17, "bsposter17", "Pinup Girl Val",                                  "Luscious Val McNeil, the vertically challenged Legal Extraordinaire, winner of Miss Space two years running and favoured pinup girl of Lawyers Weekly.")
+DEFINE_POSTER(bay_18, "bsposter18", "Derpman, Enforcer of the State",                  "Here to protect and serve... your donuts! A generously proportioned man, he teaches you the value of hiding your snacks.")
+DEFINE_POSTER(bay_19, "bsposter19", "Respect an Alien",                                "This poster depicts a well dressed looking lizard-alien receiving a prestigious award. It appears to espouse greater co-operation and harmony between the two races.")
+DEFINE_POSTER(bay_20, "bsposter20", "Alien Twilight",                                  "This poster depicts a mysteriously inscrutable, alien scene. Numerous aliens can be seen conversing amidst great, crystalline towers rising above crashing waves")
+DEFINE_POSTER(bay_21, "bsposter21", "Join the Fuzz!",                                  "It's a nice recruitment poster of a white haired Chinese woman that says; \"Big Guns, Hot Women, Good Times. Security. We get it done.\"")
+DEFINE_POSTER(bay_22, "bsposter22", "Looking for a career with excitement?",           "A recruitment poster starring a dark haired woman with glasses and a purple shirt that has \"Got Brains? Got Talent? Not afraid of electric flying monsters that want to suck the soul out of you? Then Xenobiology could use someone like you!\" written on the bottom.")
+DEFINE_POSTER(bay_23, "bsposter23", "Safety first: because electricity doesn't wait!", "A safety poster starring a clueless looking redhead with frazzled hair. \"Every year, hundreds of employees expose themselves to electric shock. Play it safe. Avoid suspicious doors after electrical storms, and always wear protection when doing electric maintenance.\"")
+DEFINE_POSTER(bay_24, "bsposter24", "Responsible medbay habits, No #259",              "A poster with a nervous looking geneticist on it states; \"Friends Tell Friends They're Clones. It can cause severe and irreparable emotional trauma if a person is not properly informed of their recent demise. Always follow your contractual obligation and inform them of their recent rejuvenation.\"")
+DEFINE_POSTER(bay_25, "bsposter25", "Irresponsible medbay habits, No #2",              "This is a safety poster starring a perverted looking naked doctor. \"Sexual harassment is never okay. REPORT any acts of sexual deviance or harassment that disrupt a healthy working environment.\"")
+DEFINE_POSTER(bay_26, "bsposter26", "The Men We Knew",                                 "This movie poster depicts a group of soldiers fighting a large exosuit, the movie seems to be a patriotic war movie.")
+DEFINE_POSTER(bay_27, "bsposter27", "Plastic Sheep Can't Scream",                      "This is a movie poster for an upcoming horror movie, it features an AI in the front of it.")
+DEFINE_POSTER(bay_28, "bsposter28", "The Stars Know Love",                             "This is a movie poster. A bleeding woman is shown drawing a heart in her blood on the window of space ship, it seems to be a romantic Drama.")
+DEFINE_POSTER(bay_29, "bsposter29", "Winter Is Coming",                                "On the poster is a frighteningly large wolf, he warns: \"Only YOU can keep humanity from freezing during planetary occultation!\"")
+DEFINE_POSTER(bay_30, "bsposter30", "Ambrosia Vulgaris",                               "Just looking at this poster makes you feel a little bit dizzy.")
+DEFINE_POSTER(bay_31, "bsposter31", "Donut Corp",                                      "This is an advertisement for Donut Corp, the new innovation in donut technology!")
+DEFINE_POSTER(bay_32, "bsposter32", "Eat!",                                            "A poster depicting a hamburger. The poster orders you to consume the hamburger.")
+DEFINE_POSTER(bay_33, "bsposter33", "Tools, tools, tools",                             "You can never have enough tools, thats for sure!")
+DEFINE_POSTER(bay_34, "bsposter34", "Power Up!",                                       "High reward, higher risk!")
+DEFINE_POSTER(bay_35, "bsposter35", "Lamarr",                                          "This is a poster depicting the pet and mascot of the science department.")
+DEFINE_POSTER(bay_36, "bsposter36", "Fancy Borg",                                      "A poster depicting a cyborg using the service module. 'Fancy Borg' is written on it.")
+DEFINE_POSTER(bay_37, "bsposter37", "Fancier Borg",                                    "A poster depicting a cyborg using the service module. 'Fancy Borg' is written on it. This is even fancier than the first poster.")
+DEFINE_POSTER(bay_38, "bsposter38", "Toaster Love",                                    "This is a poster of a toaster containing two slices of bread. The word LOVE is written in big pink letters underneath.")
+DEFINE_POSTER(bay_39, "bsposter39", "Responsible medbay habits, No #91",               "A safety poster with a chemist holding a vial. \"Always wear safety gear while handling dangerous chemicals, even if it concerns only small amounts.\"")
+DEFINE_POSTER(bay_40, "bsposter40", "Agreeable work environment",                      "This poster depicts a young woman in a stylish dress. \"Try to aim for a pleasant atmosphere in the workspace. A friendly word can do more than forms in triplicate.\"")
+DEFINE_POSTER(bay_41, "bsposter41", "Professional work environment",                   "A safety poster featuring a green haired woman in a shimmering blue dress. \"As an Internal Affairs Agent, your job is to create a fair and agreeable work environment for the crewmembers, as discreetly and professionally as possible.\"")
+DEFINE_POSTER(bay_42, "bsposter42", "Engineering pinup",                               "This is pin-up poster. A half-naked girl with white hair, toned muscles and stunning blue eyes looks back at you from the poster. Her welding helmet, tattoos and grey jumpsuit hanging around her waist gives a bit of a rugged feel.")
+DEFINE_POSTER(bay_43, "bsposter43", "Responsible medbay habits, No #3",                "A safety poster with a purple-haired surgeon. She looks a bit cross. \"Let the surgeons do their work. NEVER replace or remove a surgery tool from where the surgeon put it.\"")
 
-/decl/poster/bay_2
-	icon_state="bsposter2"
-	name = "Positronic Logic Conflicts"
-	desc = "This particular one depicts the cold, unmoving stare of a particular advanced AI."
+DEFINE_POSTER(bay_45, "bsposter45", "Responsible engineering habits, No #1",           "A safety poster featuring a blue haired engineer. \"When repairing a machine or construction, always aim for long-term solutions.\"")
+DEFINE_POSTER(bay_46, "bsposter46", "Inspirational lawyer",                            "An inspirational poster depicting an alien lawyer. He seems to be shouting something, while pointing fiercely to the right.")
+DEFINE_POSTER(bay_47, "bsposter47", "Security pinup",                                  "This is a pin-up poster. A dark skinned white haired girl poses in the sunlight wearing a tank top with her stomach exposed. The text on the poster states \"M, Succubus of Security.\" and a lipstick mark stains the top right corner, as if kissed by the model herself.")
+DEFINE_POSTER(bay_48, "bsposter48", "Borg pinup?",                                     "This is a.. pin-up poster? It is a diagram on an old model of cyborg with a note scribbled in marker on the bottom, on the top there is a large XO written in red marker.")
+DEFINE_POSTER(bay_49, "bsposter49", "Engineering recruitment",                         "This is a poster showing an engineer relaxing by a computer, the text states \"Living the life! Join Engineering today!\"")
+DEFINE_POSTER(bay_50, "bsposter50", "Pinup Girl Cindy Kate",                           "This particular one is of Cindy Kate, a seductive performer well known among less savoury circles.")
+DEFINE_POSTER(bay_51, "bsposter51", "space appreciation poster",                       "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. One of three.")
+DEFINE_POSTER(bay_52, "bsposter52", "fire safety poster",                              "This is a poster reminding you of what you should do if you are on fire, or if you are at a dance party.")
+DEFINE_POSTER(bay_53, "bsposter53", "fire extinguisher poster",                        "This is a poster reminding you of what you should use to put out a fire.")
+DEFINE_POSTER(bay_54, "bsposter54", "firefighter poster",                              "This is a poster of a particularly stern looking firefighter. The caption reads, \"Only you can prevent space fires.\"")
+DEFINE_POSTER(bay_55, "bsposter55", "Earth appreciation poster",                       "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. Two of three.")
+DEFINE_POSTER(bay_56, "bsposter56", "Mars appreciation poster",                        "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. Three of three.")
+DEFINE_POSTER(bay_57, "bsposter57", "space carp warning poster",                       "This poster tells of the dangers of space carp infestations.")
+DEFINE_POSTER(bay_58, "bsposter58", "space carp information poster",                   "This poster showcases an old spacer saying on the dangers of migrant space carp.")
+DEFINE_POSTER(bay_59, "bsposter59", "poster - Miss Science 2299",                      "A large piece of space-resistant printed paper. This pin-up poster depicts a woman wearing a corporate labcoat, a bikini, and a sheepish grin. She's shyly posing atop some highly specialized research equipment.")
 
-/decl/poster/bay_3
-	icon_state="bsposter3"
-	name = "Paranoia"
-	desc = "This particular one warns of the dangers of trusting your co-workers too much."
-
-/decl/poster/bay_4
-	icon_state="bsposter4"
-	name = "Keep Calm"
-	desc = "This particular one is of a famous New Earth design, although a bit modified. Someone has scribbled an O over the A on the poster."
-
-/decl/poster/bay_5
-	icon_state="bsposter5"
-	name = "Martian Warlord"
-	desc = "This particular one depicts the cartoony mug of a certain Martial Warmonger."
-
-/decl/poster/bay_6
-	icon_state="bsposter6"
-	name = "Technological Singularity"
-	desc = "This particular one is of the blood-curdling symbol of a long-since defeated enemy of humanity."
-
-/decl/poster/bay_7
-	icon_state="bsposter7"
-	name = "Wasteland"
-	desc = "This particular one is of a couple of ragged gunmen, one male and one female, on top of a mound of rubble. The number \"12\" is visible on their blue jumpsuits."
-
-/decl/poster/bay_8
-	icon_state="bsposter8"
-	name = "Pinup Girl Cindy"
-	desc = "This particular one is of a historical corporate PR girl, Cindy, in a particularly feminine pose."
-
-/decl/poster/bay_9
-	icon_state="bsposter9"
-	name = "Pinup Girl Amy"
-	desc = "This particular one is of Amy, the nymphomaniac urban legend of deep space. How this photograph came to be is not known."
-
-/decl/poster/bay_10
-	icon_state="bsposter10"
-	name = "Don't Panic"
-	desc = "This particular one depicts some sort of star in a grimace. The \"Don't Panic\" is written in big, friendly letters."
-
-/decl/poster/bay_11
-	icon_state="bsposter11"
-	name = "Underwater Laboratory"
-	desc = "This particular one is of the fabled last crew of a previous Company project."
-
-/decl/poster/bay_12
-	icon_state="bsposter12"
-	name = "Rogue AI"
-	desc = "This particular one depicts the shell of the infamous AI that catastropically comandeered one of humanity's earliest space stations. Back then, the Company was just known as TriOptimum."
-
-/decl/poster/bay_13
-	icon_state="bsposter13"
-	name = "User of the Arcane Arts"
-	desc = "This particular one depicts a wizard, casting a spell. You can't really make out if it's an actual photograph or a computer-generated image."
-
-/decl/poster/bay_14
-	icon_state="bsposter14"
-	name = "Levitating Skull"
-	desc = "This particular one is the portrait of a flying enchanted skull. Its adventures along with its fabled companion are now fading through history..."
-
-/decl/poster/bay_15
-	icon_state="bsposter15"
-	name = "Augmented Legend"
-	desc = "This particular one is of an obviously augmented individual, gazing towards the sky. The cyber-city in the backround is rather punkish."
-
-/decl/poster/bay_16
-	icon_state="bsposter16"
-	name = "Dangerous Static"
-	desc = "This particular one depicts nothing remarkable other than a rather mesmerising pattern of monitor static. There's a tag on the sides of the poster, but it's ripped off."
-
-/decl/poster/bay_17
-	icon_state="bsposter17"
-	name = "Pinup Girl Val"
-	desc = "Luscious Val McNeil, the vertically challenged Legal Extraordinaire, winner of Miss Space two years running and favoured pinup girl of Lawyers Weekly."
-
-/decl/poster/bay_18
-	icon_state="bsposter18"
-	name = "Derpman, Enforcer of the State"
-	desc = "Here to protect and serve... your donuts! A generously proportioned man, he teaches you the value of hiding your snacks."
-
-/decl/poster/bay_19
-	icon_state="bsposter19"
-	name = "Respect an Alien"
-	desc = "This poster depicts a well dressed looking lizard-alien receiving a prestigious award. It appears to espouse greater co-operation and harmony between the two races."
-
-/decl/poster/bay_20
-	icon_state="bsposter20"
-	name = "Alien Twilight"
-	desc = "This poster depicts a mysteriously inscrutable, alien scene. Numerous aliens can be seen conversing amidst great, crystalline towers rising above crashing waves"
-
-/decl/poster/bay_21
-	icon_state="bsposter21"
-	name = "Join the Fuzz!"
-	desc = "It's a nice recruitment poster of a white haired Chinese woman that says; \"Big Guns, Hot Women, Good Times. Security. We get it done.\""
-
-/decl/poster/bay_22
-	icon_state="bsposter22"
-	name = "Looking for a career with excitement?"
-	desc = "A recruitment poster starring a dark haired woman with glasses and a purple shirt that has \"Got Brains? Got Talent? Not afraid of electric flying monsters that want to suck the soul out of you? Then Xenobiology could use someone like you!\" written on the bottom."
-
-/decl/poster/bay_23
-	icon_state="bsposter23"
-	name = "Safety first: because electricity doesn't wait!"
-	desc = "A safety poster starring a clueless looking redhead with frazzled hair. \"Every year, hundreds of employees expose themselves to electric shock. Play it safe. Avoid suspicious doors after electrical storms, and always wear protection when doing electric maintenance.\""
-
-/decl/poster/bay_24
-	icon_state="bsposter24"
-	name = "Responsible medbay habits, No #259"
-	desc = "A poster with a nervous looking geneticist on it states; \"Friends Tell Friends They're Clones. It can cause severe and irreparable emotional trauma if a person is not properly informed of their recent demise. Always follow your contractual obligation and inform them of their recent rejuvenation.\""
-
-/decl/poster/bay_25
-	icon_state="bsposter25"
-	name = "Irresponsible medbay habits, No #2"
-	desc = "This is a safety poster starring a perverted looking naked doctor. \"Sexual harassment is never okay. REPORT any acts of sexual deviance or harassment that disrupt a healthy working environment.\""
-
-/decl/poster/bay_26
-	icon_state="bsposter26"
-	name = "The Men We Knew"
-	desc = "This movie poster depicts a group of soldiers fighting a large exosuit, the movie seems to be a patriotic war movie."
-
-/decl/poster/bay_27
-	icon_state="bsposter27"
-	name = "Plastic Sheep Can't Scream"
-	desc = "This is a movie poster for an upcoming horror movie, it features an AI in the front of it."
-
-/decl/poster/bay_28
-	icon_state="bsposter28"
-	name = "The Stars Know Love"
-	desc = "This is a movie poster. A bleeding woman is shown drawing a heart in her blood on the window of space ship, it seems to be a romantic Drama."
-
-/decl/poster/bay_29
-	icon_state="bsposter29"
-	name = "Winter Is Coming"
-	desc = "On the poster is a frighteningly large wolf, he warns: \"Only YOU can keep humanity from freezing during planetary occultation!\""
-
-/decl/poster/bay_30
-	icon_state="bsposter30"
-	name = "Ambrosia Vulgaris"
-	desc = "Just looking at this poster makes you feel a little bit dizzy."
-
-/decl/poster/bay_31
-	icon_state="bsposter31"
-	name = "Donut Corp"
-	desc = "This is an advertisement for Donut Corp, the new innovation in donut technology!"
-
-/decl/poster/bay_32
-	icon_state="bsposter32"
-	name = "Eat!"
-	desc = "A poster depicting a hamburger. The poster orders you to consume the hamburger."
-
-/decl/poster/bay_33
-	icon_state="bsposter33"
-	name = "Tools, tools, tools"
-	desc = "You can never have enough tools, thats for sure!"
-
-/decl/poster/bay_34
-	icon_state="bsposter34"
-	name = "Power Up!"
-	desc = "High reward, higher risk!"
-
-/decl/poster/bay_35
-	icon_state="bsposter35"
-	name = "Lamarr"
-	desc = "This is a poster depicting the pet and mascot of the science department."
-
-/decl/poster/bay_36
-	icon_state="bsposter36"
-	name = "Fancy Borg"
-	desc = "A poster depicting a cyborg using the service module. 'Fancy Borg' is written on it."
-
-/decl/poster/bay_37
-	icon_state="bsposter37"
-	name = "Fancier Borg"
-	desc = "A poster depicting a cyborg using the service module. 'Fancy Borg' is written on it. This is even fancier than the first poster."
-
-/decl/poster/bay_38
-	icon_state="bsposter38"
-	name = "Toaster Love"
-	desc = "This is a poster of a toaster containing two slices of bread. The word LOVE is written in big pink letters underneath."
-
-/decl/poster/bay_39
-	icon_state="bsposter39"
-	name = "Responsible medbay habits, No #91"
-	desc = "A safety poster with a chemist holding a vial. \"Always wear safety gear while handling dangerous chemicals, even if it concerns only small amounts.\""
-
-/decl/poster/bay_40
-	icon_state="bsposter40"
-	name = "Agreeable work environment"
-	desc = "This poster depicts a young woman in a stylish dress. \"Try to aim for a pleasant atmosphere in the workspace. A friendly word can do more than forms in triplicate.\""
-
-/decl/poster/bay_41
-	icon_state="bsposter41"
-	name = "Professional work environment"
-	desc = "A safety poster featuring a green haired woman in a shimmering blue dress. \"As an Internal Affairs Agent, your job is to create a fair and agreeable work environment for the crewmembers, as discreetly and professionally as possible.\""
-
-/decl/poster/bay_42
-	icon_state="bsposter42"
-	name = "Engineering pinup"
-	desc = "This is pin-up poster. A half-naked girl with white hair, toned muscles and stunning blue eyes looks back at you from the poster. Her welding helmet, tattoos and grey jumpsuit hanging around her waist gives a bit of a rugged feel."
-
-/decl/poster/bay_43
-	icon_state="bsposter43"
-	name = "Responsible medbay habits, No #3"
-	desc = "A safety poster with a purple-haired surgeon. She looks a bit cross. \"Let the surgeons do their work. NEVER replace or remove a surgery tool from where the surgeon put it.\""
-
-/decl/poster/bay_45
-	icon_state="bsposter45"
-	name = "Responsible engineering habits, No #1"
-	desc = "A safety poster featuring a blue haired engineer. \"When repairing a machine or construction, always aim for long-term solutions.\""
-
-/decl/poster/bay_46
-	icon_state="bsposter46"
-	name = "Inspirational lawyer"
-	desc = "An inspirational poster depicting an alien lawyer. He seems to be shouting something, while pointing fiercely to the right."
-
-/decl/poster/bay_47
-	icon_state="bsposter47"
-	name = "Security pinup"
-	desc = "This is a pin-up poster. A dark skinned white haired girl poses in the sunlight wearing a tank top with her stomach exposed. The text on the poster states \"M, Succubus of Security.\" and a lipstick mark stains the top right corner, as if kissed by the model herself."
-
-/decl/poster/bay_48
-	icon_state="bsposter48"
-	name = "Borg pinup?"
-	desc = "This is a.. pin-up poster? It is a diagram on an old model of cyborg with a note scribbled in marker on the bottom, on the top there is a large XO written in red marker."
-
-/decl/poster/bay_49
-	icon_state="bsposter49"
-	name = "Engineering recruitment"
-	desc = "This is a poster showing an engineer relaxing by a computer, the text states \"Living the life! Join Engineering today!\""
-
-/decl/poster/bay_50
-	icon_state="bsposter50"
-	name = "Pinup Girl Cindy Kate"
-	desc = "This particular one is of Cindy Kate, a seductive performer well known among less savoury circles."
-
-/decl/poster/bay_51
-	icon_state="bsposter51"
-	name = "space appreciation poster"
-	desc = "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. One of three."
-
-/decl/poster/bay_52
-	icon_state="bsposter52"
-	name = "fire safety poster"
-	desc = "This is a poster reminding you of what you should do if you are on fire, or if you are at a dance party."
-
-/decl/poster/bay_53
-	icon_state="bsposter53"
-	name = "fire extinguisher poster"
-	desc = "This is a poster reminding you of what you should use to put out a fire."
-
-/decl/poster/bay_54
-	icon_state="bsposter54"
-	name = "firefighter poster"
-	desc = "This is a poster of a particularly stern looking firefighter. The caption reads, \"Only you can prevent space fires.\""
-
-/decl/poster/bay_55
-	icon_state="bsposter55"
-	name = "Earth appreciation poster"
-	desc = "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. Two of three."
-
-/decl/poster/bay_56
-	icon_state="bsposter56"
-	name = "Mars appreciation poster"
-	desc = "This is a poster produced by the Generic Space Company, as a part of a series of commemorative posters on the wonders of space. Three of three."
-
-/decl/poster/bay_57
-	icon_state="bsposter57"
-	name = "space carp warning poster"
-	desc = "This poster tells of the dangers of space carp infestations."
-
-/decl/poster/bay_58
-	icon_state="bsposter58"
-	name = "space carp information poster"
-	desc = "This poster showcases an old spacer saying on the dangers of migrant space carp."
-
-/decl/poster/bay_59
-	icon_state="bsposter59"
-	name = "poster - Miss Science 2299"
-	desc = "A large piece of space-resistant printed paper. This pin-up poster depicts a woman wearing a corporate labcoat, a bikini, and a sheepish grin. She's shyly posing atop some highly specialized research equipment."
+#undef DEFINE_POSTER


### PR DESCRIPTION
## Description of changes
Posters were turned into datums and nobody implemented a way to place them individually. So I had to make one.
Added a macro to declare posters and declare a template class. Each with a name and an a mapper icon.
