### PR TITLE
Minor bugfix on basic industrial infini-vend

### DIFF
--- a/mods/persistence/modules/chargen/vending/industrial.dm
+++ b/mods/persistence/modules/chargen/vending/industrial.dm
@@ -36,7 +36,6 @@
 	products = list(
 		/obj/item/chargen_box/industrial/engineering = 999,
 		/obj/item/chargen_box/industrial/firefighter = 999,
-		/obj/item/chargen_box/industrial/building = 999,
 		/obj/item/chargen_box/industrial/autolathe = 999,
 		/obj/item/chargen_box/industrial/mining = 999,
 		/obj/item/chargen_box/industrial/pick = 999,


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

When I originally made the basic infini-vend, I neglected to remove the 'assorted building materials' thing; this effectively rendered the basic version to be equally as good as the deluxe version (one with infinite mats intentionally)

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This will make it so the basic infini-vend can actually function as a infini-vend with no infinite materials.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
fix: The basic engineering infini-vendor no longer has the 'assorted building materials' item in stock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->