### PR TITLE
Adds a Reduced Stock Variant of the Science/Medicine Infini-Vendor

### DIFF
--- a/mods/persistence/modules/chargen/vending/science.dm
+++ b/mods/persistence/modules/chargen/vending/science.dm
@@ -1,6 +1,6 @@
 /obj/machinery/vending/infini/science
-	name = "NanoSci Plus"
-	desc = "Medical drug & science dispenser."
+	name = "FrontierTek Plus"
+	desc = "An automated synthesizer machine that can print basic science and medical equipment, in addition to an assortment of medical supplies and drugs."
 	icon_state = "med"
 	icon_deny = "med-deny"
 	icon_vend = "med-vend"
@@ -19,3 +19,15 @@
 		/obj/item/chargen_box/science/oxyloss = 999
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
+
+	/obj/machinery/vending/infini/science/basic
+	name = "FrontierTek Plus Minus"
+	desc = "An automated synthesizer that can print basic science and medical equipment. This vendor in particular seems to lack the appropriate modules to synthesize medicine."
+	base_type = /obj/machinery/vending/infini/science/basic
+	products = list(
+		/obj/item/chargen_box/science/rnd = 999,
+		/obj/item/chargen_box/science/chem = 999,
+		/obj/item/chargen_box/science/emt = 999,
+		/obj/item/chargen_box/science/surgery = 999
+	)
+	

--- a/mods/persistence/modules/chargen/vending/science.dm
+++ b/mods/persistence/modules/chargen/vending/science.dm
@@ -20,7 +20,7 @@
 	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
-	/obj/machinery/vending/infini/science/basic
+/obj/machinery/vending/infini/science/basic
 	name = "FrontierTek Plus Minus"
 	desc = "An automated synthesizer that can print basic science and medical equipment. This vendor in particular seems to lack the appropriate modules to synthesize medicine."
 	base_type = /obj/machinery/vending/infini/science/basic


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a 'basic' variant of the science infini-vend that lacks the medicine stock to encourage people to actually make their own medicine, while still giving them access to RND.

Keeps the old 'deluxe' variant for testing purposes.

Also renames it to the 'FrontierTek' because NT isn't a thing out here on the frontier

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This will allow players to acquire RND from the infini-vendors without also giving them an infinite amount of medicine to heal their wounds with, which will encourage botany for medicinal uses and chemistry.

## Authorship
<!-- Describe original authors of changes to credit them. -->

genessee did this

## Changelog
:cl:
add: Basic variant of the Science infini-vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->