### PR TITLE
Null Drink Name Fix

### DIFF
--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -8,6 +8,7 @@
 	icon_state = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_HOLLOW
+	presentation_flags = PRESENTATION_FLAG_NAME
 	possible_transfer_amounts = null
 	amount_per_transfer_from_this = 5
 	randpixel = 6
@@ -130,6 +131,7 @@
 	icon_state = "milk"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':9}"
+	presentation_flags = null
 
 /obj/item/chems/drinks/milk/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk, reagents.maximum_volume)
@@ -140,6 +142,7 @@
 	icon_state = "soymilk"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':9}"
+	presentation_flags = null
 
 /obj/item/chems/drinks/soymilk/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk/soymilk, reagents.maximum_volume)
@@ -148,6 +151,7 @@
 	name = "small milk carton"
 	volume = 30
 	icon_state = "mini-milk"
+	presentation_flags = null
 
 /obj/item/chems/drinks/milk/smallcarton/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk, reagents.maximum_volume)
@@ -164,6 +168,7 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "coffee"
 	center_of_mass = @"{'x':15,'y':10}"
+	base_name = "cup"
 
 /obj/item/chems/drinks/coffee/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/coffee, reagents.maximum_volume)
@@ -173,6 +178,7 @@
 	desc = "Careful, cold ice, do not chew."
 	icon_state = "coffee"
 	center_of_mass = @"{'x':15,'y':10}"
+	base_name = "cup"
 
 /obj/item/chems/drinks/ice/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/ice, reagents.maximum_volume)
@@ -183,6 +189,7 @@
 	icon_state = "coffee"
 	item_state = "coffee"
 	center_of_mass = @"{'x':15,'y':13}"
+	base_name = "cup"
 
 /obj/item/chems/drinks/h_chocolate/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/hot_coco, reagents.maximum_volume)
@@ -193,6 +200,7 @@
 	desc = "Just add 10ml water, self heats! A taste that reminds you of your school years."
 	icon_state = "ramen"
 	center_of_mass = @"{'x':16,'y':11}"
+	base_name = "cup"
 
 /obj/item/chems/drinks/dry_ramen/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/dry_ramen, reagents.maximum_volume)
@@ -245,6 +253,7 @@
 	icon_state = "flask"
 	volume = 60
 	center_of_mass = @"{'x':17,'y':7}"
+	presentation_flags = null
 
 /obj/item/chems/drinks/flask/shiny
 	name = "shiny flask"

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -16,11 +16,6 @@
 	var/filling_states   // List of percentages full that have icons
 	var/base_icon = null // Base icon name for fill states
 
-/obj/item/chems/drinks/Initialize()
-	. = ..()
-	if(!base_name)
-		base_name = name
-
 /obj/item/chems/drinks/dragged_onto(var/mob/user)
 	attack_self(user)
 
@@ -98,9 +93,6 @@
 	for(var/k in cached_json_decode(filling_states))
 		if(percent <= k)
 			return k
-
-/obj/item/chems/drinks/get_base_name()
-	. = base_name
 
 /obj/item/chems/drinks/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -8,7 +8,6 @@
 	icon_state = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_HOLLOW
-	presentation_flags = PRESENTATION_FLAG_NAME
 	possible_transfer_amounts = null
 	amount_per_transfer_from_this = 5
 	randpixel = 6
@@ -16,6 +15,11 @@
 
 	var/filling_states   // List of percentages full that have icons
 	var/base_icon = null // Base icon name for fill states
+
+/obj/item/chems/drinks/Initialize()
+	if(!base_name)
+		base_name = name
+	. = ..()
 
 /obj/item/chems/drinks/dragged_onto(var/mob/user)
 	attack_self(user)
@@ -95,6 +99,9 @@
 		if(percent <= k)
 			return k
 
+/obj/item/chems/drinks/get_base_name()
+	. = base_name
+
 /obj/item/chems/drinks/on_update_icon()
 	. = ..()
 	if(LAZYLEN(reagents.reagent_volumes))
@@ -131,7 +138,6 @@
 	icon_state = "milk"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':9}"
-	presentation_flags = null
 
 /obj/item/chems/drinks/milk/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk, reagents.maximum_volume)
@@ -142,7 +148,6 @@
 	icon_state = "soymilk"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':9}"
-	presentation_flags = null
 
 /obj/item/chems/drinks/soymilk/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk/soymilk, reagents.maximum_volume)
@@ -151,7 +156,6 @@
 	name = "small milk carton"
 	volume = 30
 	icon_state = "mini-milk"
-	presentation_flags = null
 
 /obj/item/chems/drinks/milk/smallcarton/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk, reagents.maximum_volume)
@@ -168,7 +172,6 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "coffee"
 	center_of_mass = @"{'x':15,'y':10}"
-	base_name = "cup"
 
 /obj/item/chems/drinks/coffee/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/coffee, reagents.maximum_volume)
@@ -178,7 +181,6 @@
 	desc = "Careful, cold ice, do not chew."
 	icon_state = "coffee"
 	center_of_mass = @"{'x':15,'y':10}"
-	base_name = "cup"
 
 /obj/item/chems/drinks/ice/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/ice, reagents.maximum_volume)
@@ -189,7 +191,6 @@
 	icon_state = "coffee"
 	item_state = "coffee"
 	center_of_mass = @"{'x':15,'y':13}"
-	base_name = "cup"
 
 /obj/item/chems/drinks/h_chocolate/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/hot_coco, reagents.maximum_volume)
@@ -200,7 +201,6 @@
 	desc = "Just add 10ml water, self heats! A taste that reminds you of your school years."
 	icon_state = "ramen"
 	center_of_mass = @"{'x':16,'y':11}"
-	base_name = "cup"
 
 /obj/item/chems/drinks/dry_ramen/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/dry_ramen, reagents.maximum_volume)
@@ -253,7 +253,6 @@
 	icon_state = "flask"
 	volume = 60
 	center_of_mass = @"{'x':17,'y':7}"
-	presentation_flags = null
 
 /obj/item/chems/drinks/flask/shiny
 	name = "shiny flask"
@@ -297,6 +296,7 @@
 	base_name = "cup"
 	base_icon = "cup"
 	volume = 30
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/drinks/tea/black
 	name = "cup of black tea"
@@ -318,4 +318,3 @@
 
 /obj/item/chems/drinks/tea/chai/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/tea/chai, reagents.maximum_volume)
-

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -172,6 +172,8 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "coffee"
 	center_of_mass = @"{'x':15,'y':10}"
+	base_name = "cup"
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/drinks/coffee/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/coffee, reagents.maximum_volume)
@@ -212,6 +214,7 @@
 	possible_transfer_amounts = null
 	volume = 10
 	center_of_mass = @"{'x':16,'y':12}"
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/drinks/sillycup/on_update_icon()
 	. = ..()
@@ -246,6 +249,7 @@
 	filling_states = @"[15,30,50,70,85,100]"
 	base_icon = "pitcher"
 	material = /decl/material/solid/metal/stainlesssteel
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/drinks/flask
 	name = "\improper Captain's flask"

--- a/code/modules/reagents/reagent_containers/drinks/cans.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cans.dm
@@ -3,6 +3,7 @@
 	amount_per_transfer_from_this = 5
 	atom_flags = 0 //starts closed
 	material = /decl/material/solid/metal/aluminium
+	presentation_flags = null
 
 /obj/item/chems/drinks/cans/on_reagent_change()
 	return

--- a/code/modules/reagents/reagent_containers/drinks/juicebox.dm
+++ b/code/modules/reagents/reagent_containers/drinks/juicebox.dm
@@ -7,6 +7,7 @@
 	amount_per_transfer_from_this = 5
 	atom_flags = 0
 	material = /decl/material/solid/cardboard
+	presentation_flags = null
 
 	color = "#ff0000"
 	var/primary_color = "#ff0000"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -256,6 +256,7 @@
 
 /obj/item/chems/pill/detergent
 	name = "detergent pod"
+	base_name = "detergent pod" // wouldn't make sense for it to be named "pill"
 	desc = "Put in water to get space cleaner. Do not eat. Really."
 	icon_state = "pod21"
 	var/smell_clean_time = 10 MINUTES
@@ -265,29 +266,34 @@
 
 /obj/item/chems/pill/pod
 	name = "master flavorpod item"
+	base_name = "master flavorpod item"
 	desc = "A cellulose pod containing some kind of flavoring."
 	icon_state = "pill4"
 
 /obj/item/chems/pill/pod/cream
 	name = "creamer pod"
+	base_name = "creamer pod"
 
 /obj/item/chems/pill/pod/cream/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk, 5)
 
 /obj/item/chems/pill/pod/cream_soy
 	name = "non-dairy creamer pod"
+	base_name = "non-dairy creamer pod"
 
 /obj/item/chems/pill/pod/cream_soy/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/milk/soymilk, 5)
 
 /obj/item/chems/pill/pod/orange
 	name = "orange flavorpod"
+	base_name = "orange flavorpod"
 
 /obj/item/chems/pill/pod/orange/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/juice/orange, 5)
 
 /obj/item/chems/pill/pod/mint
 	name = "mint flavorpod"
+	base_name = "mint flavorpod"
 
 /obj/item/chems/pill/pod/mint/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/syrup/mint, 1)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Fixes the null name bug on drinks via upstream, and lets a few drink containers show their contents

## Why and what will this PR improve
Having a smaller number of bugs is nice, as well as properly listing what's in vending machines

## Authorship
pitaden (after being conscripted by genessee)

## Changelog
:cl:
bugfix: fixed invisible/non-descriptive drink names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->