### PR TITLE
APCs no longer save areas

### DIFF
--- a/mods/persistence/modules/power/apc.dm
+++ b/mods/persistence/modules/power/apc.dm
@@ -14,7 +14,6 @@
 ///////////////////////////////////////////////////
 // Saved Var Define
 ///////////////////////////////////////////////////
-SAVED_VAR(/obj/machinery/power/apc, area)
 SAVED_VAR(/obj/machinery/power/apc, shorted)
 SAVED_VAR(/obj/machinery/power/apc, lighting)
 SAVED_VAR(/obj/machinery/power/apc, equipment)


### PR DESCRIPTION
## Description of changes
Stops APCs from saving areas. This fixes an error from a failed ASSERT on load. Since APCs auto-locate their areas regardless, this shouldn't be an issue.