### PR TITLE
Fix airlock sensor updating

### DIFF
--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -165,7 +165,9 @@
 		var/datum/gas_mixture/air_sample = return_air()
 		var/new_pressure = round(air_sample.return_pressure(),0.1)
 
-		if(abs(pressure - new_pressure) > 0.001 || pressure == null)
+		//Try preventing the sensor from spamming when there's no differences, and the controller isn't cycling.
+		//Can't rely only on difference, since it's possible for the pressure to stay nearly the same for a few calls, which prevents the machine var from updating
+		if(abs(pressure - new_pressure) > 0.001 || master_cycling)
 			var/decl/public_access/public_variable/airlock_pressure/pressure_var = GET_DECL(/decl/public_access/public_variable/airlock_pressure)
 			pressure_var.write_var(src, new_pressure)
 

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -89,8 +89,7 @@
 	if(!receive_tag) return
 
 	if(receive_tag==tag_chamber_sensor)
-		if(signal.data["pressure"])
-			memory["chamber_sensor_pressure"] = text2num(signal.data["pressure"])
+		memory["chamber_sensor_pressure"] = text2num(signal.data["pressure"])
 
 	else if(receive_tag==tag_exterior_sensor)
 		memory["external_sensor_pressure"] = text2num(signal.data["pressure"])


### PR DESCRIPTION
## Description of changes
Airlock would get stuck while purging the airlock chamber because the sensor wasn't updating while cycling and it also would sometimes not communicate that the pressure reached 0.
