### PR TITLE
Fix omni filter display

### DIFF
--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -163,7 +163,10 @@
 	return data
 
 /obj/machinery/atmospherics/omni/filter/proc/mode_send_switch(var/datum/omni_port/P)
-	if(P.filtering)
+	if(istype(P.filtering, /decl/material))
+		var/decl/material/gas/G = P.filtering
+		return G.gas_symbol
+	if(ispath(P.filtering))
 		var/decl/material/gas/G = GET_DECL(P.filtering)
 		return G.gas_symbol
 

--- a/nano/templates/omni_filter.tmpl
+++ b/nano/templates/omni_filter.tmpl
@@ -82,7 +82,7 @@
                                 Input
                             {{else value.output}}
                                 Output
-                            {{else value.f_type}}
+                            {{else value.filter}}
                                 {{:value.f_type}}
                             {{else}}
                                 Disabled


### PR DESCRIPTION
## Description of changes
The omni filter would display the wrong filtered gas under a very specific situation.
