### PR TITLE
Fix offset terminal not facing the right place

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -188,4 +188,5 @@
 	. = ..(machine, part, get_step(machine.loc, machine.dir))
 
 /decl/stock_part_preset/terminal_setup/offset_dir/apply(obj/machinery/machine, obj/item/stock_parts/power/terminal/part)
+	part.terminal_dir = machine.dir //Make the terminal in the direction we're facing
 	. = ..(machine, part)


### PR DESCRIPTION
## Description of changes
Make the offset power terminal part template make it face the right way on the right turf.