### PR TITLE
Prevent doors updating connections on load

### DIFF
--- a/mods/persistence/game/machinery/doors/_door.dm
+++ b/mods/persistence/game/machinery/doors/_door.dm
@@ -11,3 +11,7 @@
 	if(persistent_id)
 		return ..(mapload, dir, FALSE)
 	return ..()
+
+/obj/machinery/door/update_connections(propagate)
+	if(!persistent_id) //Don't let it do this when loading from save
+		. = ..()


### PR DESCRIPTION

## Description of changes
Prevents doors from trying to align themselves to walls and other things around them when loaded from save. This prevents doorpocalypse.
