### PR TITLE
Code quality check fix

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -19,7 +19,7 @@
 
 	var/started_on 			= 0 	// When the program started some science.
 	var/current_interval 	= 0		// How long the current interval will be.
-	var/next_event 			= 0 	// in world timeofday, when the next event is scheduled to pop.
+	var/next_event 			= 0 	// Based on world.timeofday, when the next event is scheduled to pop.
 	var/crashed				= FALSE	// Program periodically needs a restart.
 	var/crashed_at			= 0		// When the program crashed.
 


### PR DESCRIPTION
## Description of changes
Code quality checks for usage of "in world" catch uses of in world in comments and count it as a failure. Removed the latest addition so it stops whining.
