### PR TITLE
make sure parts are initialized on machine init

### DIFF
--- a/mods/persistence/game/machinery/machinery.dm
+++ b/mods/persistence/game/machinery/machinery.dm
@@ -16,6 +16,8 @@
 		if(length(old_cpart))
 			for(var/obj/item/stock_parts/P in old_cpart)
 				if(!(P in component_parts))
+					if(!(P.atom_flags & ATOM_FLAG_INITIALIZED))
+						SSatoms.InitAtom(P) //Make sure parts are initialized first!
 					install_component(P, FALSE, FALSE)
 			RefreshParts()
 		CLEAR_SV("old_component_parts")


### PR DESCRIPTION
## Description of changes
Some very specific parts have things to init before being installed. Like network receivers. And some specific machines need it to be initialized early(air alarms apparently). 
So, made this patch for now. This isn't ideal though.
