### PR TITLE
Assorted character fixes

### DIFF
--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -199,8 +199,9 @@ var/global/arrest_security_status =  "Arrest"
 
 //Should only be used for OOC stuff, for player-facing stuff you must go through the network.
 /proc/get_crewmember_record(var/name)
+	var/sanitized_name = sanitize(name)
 	for(var/datum/computer_file/report/crew_record/CR in global.all_crew_records)
-		if(CR.get_name() == name)
+		if(CR.get_name() == sanitized_name)
 			return CR
 	return null
 

--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -597,7 +597,7 @@
 	. = one_off.AddToLimbo(things, key, limbo_type, metadata, metadata2, modify)
 	if(.) // Clear it from the queued removals.
 		for(var/list/queued in limbo_removals)
-			if(queued[1] == key && queued[2] == limbo_type)
+			if(queued[1] == sanitize_sql(key) && queued[2] == limbo_type)
 				limbo_removals -= list(queued)
 	if(new_db_connection)
 		close_save_db_connection()
@@ -619,7 +619,7 @@
 		new_db_connection = TRUE
 	. = one_off.DeserializeOneOff(limbo_key, limbo_type, remove_after)
 	if(remove_after)
-		limbo_removals += list(list(limbo_key, limbo_type))
+		limbo_removals += list(list(sanitize_sql(limbo_key), limbo_type))
 	if(new_db_connection)
 		close_save_db_connection()
 

--- a/mods/persistence/modules/chargen/launch_pod.dm
+++ b/mods/persistence/modules/chargen/launch_pod.dm
@@ -77,7 +77,7 @@
 
 	// Add the mob to limbo for safety. Mark for removal on the next save.
 	SSpersistence.AddToLimbo(list(user, user.mind), user.mind.unique_id, LIMBO_MIND, user.mind.key, user.mind.current.real_name, TRUE)
-	SSpersistence.limbo_removals += list(list(user.mind.unique_id, LIMBO_MIND))
+	SSpersistence.limbo_removals += list(list(sanitize_sql(user.mind.unique_id), LIMBO_MIND))
 
 	for(var/turf/T in global.latejoin_cryo_locations)
 		var/obj/machinery/cryopod/C = locate() in T

--- a/mods/persistence/modules/client/preferences.dm
+++ b/mods/persistence/modules/client/preferences.dm
@@ -72,7 +72,7 @@
 				to_chat(usr, "<span class='danger'>[real_name] is already a name in use! Please select a different name.</span>")
 				real_name = null
 				return
-		var/DBQuery/char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata2` = '[real_name]'")
+		var/DBQuery/char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata2` = '[sanitize_sql(real_name)]'")
 		if(!char_query.Execute())
 			to_world_log("DUPLICATE NAME CHECK DESERIALIZATION FAILED: [char_query.ErrorMsg()].")
 		if(char_query.NextRow())
@@ -83,7 +83,7 @@
 		if(check_rights(R_DEBUG) || check_rights(R_ADMIN))
 			slots+=2
 		var/count = 0
-		char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata` = '[client.key]'")
+		char_query = dbcon.NewQuery("SELECT `key` FROM `limbo` WHERE `type` = '[LIMBO_MIND]' AND `metadata` = '[sanitize_sql(client.key)]'")
 		if(!char_query.Execute())
 			to_world_log("CHARACTER DESERIALIZATION FAILED: [char_query.ErrorMsg()].")
 		for(var/i=1,i>=slots,i++)
@@ -97,12 +97,12 @@
 
 		save_preferences()
 		save_character()
-		
+
 		if(isnewplayer(client.mob))
 			close_char_dialog(usr)
 			var/mob/new_player/M = client.mob
 			M.AttemptLateSpawn(SSjobs.get_by_path(global.using_map.default_job_type))
-			
+
 
 	if(href_list["save"])
 		save_preferences()

--- a/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/one_off_serializer.dm
@@ -179,7 +179,7 @@
 	var/encoded_p_ids = json_encode(thing_p_ids)
 	// Insert into the limbo table, a metadata holder that allows for access to the limbo_assoc key by 'type' and 'key'.
 	var/DBQuery/insert_query
-	insert_query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIMBO]` (`key`,`type`,`p_ids`,`metadata`,`limbo_assoc`, `metadata2`) VALUES('[key]', '[limbo_type]', '[encoded_p_ids]', '[metadata]', '[limbo_assoc]', '[metadata2]')")
+	insert_query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_LIMBO]` (`key`,`type`,`p_ids`,`metadata`,`limbo_assoc`,`metadata2`) VALUES('[key]', '[limbo_type]', '[encoded_p_ids]', '[metadata]', '[limbo_assoc]', '[metadata2]')")
 
 	try
 		SQLS_EXECUTE_AND_REPORT_ERROR(insert_query, "LIMBO ADDITION FAILED:")
@@ -207,6 +207,9 @@
 
 // Removes an object from the limbo table. This should always be called after an object is deserialized from limbo into the world.
 /serializer/sql/one_off/proc/RemoveFromLimbo(var/limbo_key, var/limbo_type)
+
+	limbo_key = sanitize_sql(limbo_key)
+
 	var/DBQuery/limbo_query = dbcon_save.NewQuery("SELECT `limbo_assoc` FROM `[SQLS_TABLE_LIMBO]` WHERE `key` = '[limbo_key]' AND `type` = '[limbo_type]';")
 	var/limbo_assoc
 	SQLS_EXECUTE_AND_REPORT_ERROR(limbo_query, "LIMBO QUERY FAILED DURING LIMBO REMOVAL:")


### PR DESCRIPTION
## Description of changes
Fixes being unable to load in with characters with apostrophes/other special characters in their names. This was caused by some missing sanitization in SQL statements and Topic. Also fixes the "Error: you are not an admin" spam created by some missing arguments in checking permissions.

One change should eventually be set upstream: crew records checking against sanitized names in ``get_crew_record``, since this also breaks with apostrophes etc.

## Authorship
Myself. Thanks to Unleashed for finding these bugs.