### PR TITLE
Fixes level order

### DIFF
--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -628,6 +628,7 @@ var/global/list/serialization_time_spent_type
 		var/datum/persistence/load_cache/z_level/z_level = z_transform[z]
 		z_inserts += "([z_insert_index],[z_level.new_index],[z_level.dynamic],'[z_level.default_turf]','[z_level.metadata]','[json_encode(z_level.areas)]','[z_level.level_data_subtype]')"
 		z_insert_index++
+
 	var/DBQuery/query = dbcon_save.NewQuery("INSERT INTO `[SQLS_TABLE_Z_LEVELS]` (`id`,`z`,`dynamic`,`default_turf`,`metadata`,`areas`,`level_data_subtype`) VALUES[jointext(z_inserts, ",")]")
 	SQLS_EXECUTE_AND_REPORT_ERROR(query, "Z_LEVEL SERIALIZATION FAILED:")
 	return TRUE

--- a/mods/persistence/modules/world_save/wrappers/map_data_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/map_data_wrapper.dm
@@ -13,10 +13,14 @@
 	var/turf/T = get_turf(M)
 	height = M.height
 	landmark_loc = "[T.x],[T.y],[T.z]"
-	
+
 /datum/wrapper/map_data/on_deserialize(var/serializer/curr_serializer)
 	var/list/coords = splittext(landmark_loc, ",")
 	report_progress_serializer("Deserialized map data on z [text2num(coords[3])]")
-	var/turf/T = locate(text2num(coords[1]), text2num(coords[2]), text2num(coords[3]))
+
+	var/adjusted_z = text2num(coords[3])
+	if(curr_serializer.z_map[num2text(adjusted_z)])
+		adjusted_z = curr_serializer.z_map[num2text(adjusted_z)]
+
+	var/turf/T = locate(text2num(coords[1]), text2num(coords[2]), adjusted_z)
 	return new /obj/abstract/map_data(T, text2num(height))
-	


### PR DESCRIPTION
## Description of changes
Adjusts the level ordering code so that mapped levels are offset in case that ``world.maxz`` is greater than the minimum mapped z-index in the database. This solves an issue that was occurring with templates that are spawned pre-load (like the supply shuttle) getting overridden. Also makes it so that levels are always spawned with the correct level data, since the game doesn't like having duplicates of the Kleibkhar level datas, since they have a static ID.