### PR TITLE
Fixes at least one cause of missing arms on load

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -1,8 +1,9 @@
-/mob/living/carbon/human/proc/update_eyes()
+/mob/living/carbon/human/proc/update_eyes(update_icon = TRUE)
 	var/obj/item/organ/internal/eyes/eyes = get_organ((species?.vision_organ || BP_EYES), /obj/item/organ/internal/eyes)
 	if(eyes)
 		eyes.update_colour()
-		refresh_visible_overlays()
+		if(update_icon)
+			refresh_visible_overlays()
 
 /mob/living/carbon/human/proc/get_bodypart_name(var/zone)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, zone)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -101,7 +101,7 @@
 	// Apply our eye colour to the target.
 	if(istype(target) && eye_colour)
 		target.eye_colour = eye_colour
-		target.update_eyes()
+		target.update_eyes(update_icon)
 	if(owner && BP_IS_PROSTHETIC(src))
 		verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 		verbs |= /obj/item/organ/internal/eyes/proc/toggle_eye_glow


### PR DESCRIPTION
## Description of changes
Adds a check to prevent eye organ installation rebuilding human icons too early (during deserialization), causing icon cache corruption and missing icons for human arms and hands on load. Theoretically anything that calls ``update_body`` too early could cause this issue, but from at least my quick testing, this is the lone offender atm.

This could go upstream, but I'd like to be sure it solves the problem and we don't need to add additional checks in strange circumstances later.

## Authorship
Myself. Thanks to Psy and Nebula for helpful discussions.