### PR TITLE
Update reaction_grenade_reaction, hopefully solving issue #445 partially

### DIFF
--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -50,7 +50,8 @@
 	lore_text = "This reaction causes an electromagnetic pulse that knocks out machinery in a sizable radius."
 	required_reagents = list(
 		/decl/material/solid/metal/uranium = 1,
-		/decl/material/solid/metal/iron = 1
+		/decl/material/solid/metal/iron = 1,
+		/decl/material/liquid/acid/polyacid = 1 //Prevents EMP pulse from occuring inside of mining machinery on accident
 	) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 	result_amount = 2
 	mix_message = "The solution bubbles vigorously!"


### PR DESCRIPTION
## Description of changes
Modifies the EMP reaction to include a reagent to prevent EMP pulse in mining equipment, also makes it more justifiable using pseudoscience (something something solvents causing the iron and uranium to change into reagents that cause an exothermic reaction blah blah blah)

## Why and what will this PR improve
prevents accidental EMPs in mining equipment, half-way solves issue #445 (I'm not going to actually modify the EMP pulse itself, that is a bit above my paygrade)

## Authorship
It's me! With guidance from psy_commando

## Changelog
:cl:
add: polytrinic acid to reaction
tweak: modified EMP reaction to include a reagent not directly gained through mining (hopefully)
/:cl: