### PR TITLE
Add 12g ammo and sawn-off shotgun to fabricator list

### DIFF
--- a/mods/persistence/modules/fabrication/designs/protolathe/designs_ammunition.dm
+++ b/mods/persistence/modules/fabrication/designs/protolathe/designs_ammunition.dm
@@ -33,3 +33,15 @@
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/box/tier1
 	path = /obj/item/ammo_magazine/box/fortyfive/simple
+
+/datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/slug/tier0
+	path = /obj/item/ammo_magazine/box/twelvegauge/slug/handmade
+
+/datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/buckshot/tier0
+	path = /obj/item/ammo_magazine/box/twelvegauge/buckshot/handmade
+
+/datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/slug/tier1
+	path = /obj/item/ammo_magazine/box/twelvegauge/slug/simple
+
+/datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/buckshot/tier1
+	path = /obj/item/ammo_magazine/box/twelvegauge/buckshot/simple

--- a/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
+++ b/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
@@ -31,6 +31,9 @@
 /datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_double
 	path = /obj/item/gun/projectile/shotgun/simple/empty
 
+/datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_double_sawn
+	path = /obj/item/gun/projectile/shotgun/simple/sawnoff/empty
+
 /datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_pump
 	path = /obj/item/gun/projectile/shotgun/pump/simple/empty
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
I was skimming the changes I made in #463 and realized I forgot to add 12g ammo or the sawn-off to the fabricator list. This adds those things to the list so they can be printed.

## Why and what will this PR improve
This makes 12g ammo and the sawn-off printable in-game as intended.

## Authorship
genessee did this

## Changelog
:cl:
bugfix: 12g ammo and the sawn-off shotgun can now be printed in the fabricator when researched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->