### PR TITLE
Fixes PID Collisions

### DIFF
--- a/mods/persistence/code/__defines/persistent_id.dm
+++ b/mods/persistence/code/__defines/persistent_id.dm
@@ -1,1 +1,2 @@
-#define PERSISTENT_ID uniqueness_repository.Generate(/datum/uniqueness_generator/hex)
+// Does not use the uniqueness repository to eliminate unnecessary overhead
+#define PERSISTENT_ID "[RANDBYTE]-[RANDBYTE]-[RANDBYTE]-[RANDBYTE]-[RANDBYTE]-[RANDBYTE]"

--- a/sql/V100__Persistence.sql
+++ b/sql/V100__Persistence.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS `list_element` (
 -- Dumping structure for table persistent.thing
 DROP TABLE IF EXISTS `thing`;
 CREATE TABLE IF NOT EXISTS `thing` (
-  `p_id` varchar(12) NOT NULL,
+  `p_id` varchar(18) NOT NULL,
   `type` varchar(256) NOT NULL,
   `x` int DEFAULT NULL,
   `y` int DEFAULT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS `thing` (
 DROP TABLE IF EXISTS `thing_var`;
 CREATE TABLE IF NOT EXISTS `thing_var` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `thing_id` varchar(12) NOT NULL,
+  `thing_id` varchar(18) NOT NULL,
   `key` varchar(256) NOT NULL,
   `type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS `limbo` (
   `type` varchar(64) NOT NULL,
   `p_ids` longtext NOT NULL,
   `metadata` varchar(64) DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   `metadata2` varchar(64) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
 
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS `limbo_list_element` (
   `key_type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
   `value_type` varchar(256) NOT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -96,12 +96,12 @@ CREATE TABLE IF NOT EXISTS `limbo_list_element` (
 -- Dumping structure for table persistent.thing
 DROP TABLE IF EXISTS `limbo_thing`;
 CREATE TABLE IF NOT EXISTS `limbo_thing` (
-  `p_id` varchar(12) NOT NULL,
+  `p_id` varchar(18) NOT NULL,
   `type` varchar(256) NOT NULL,
   `x` int DEFAULT NULL,
   `y` int DEFAULT NULL,
   `z` int DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`p_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -110,11 +110,11 @@ CREATE TABLE IF NOT EXISTS `limbo_thing` (
 DROP TABLE IF EXISTS `limbo_thing_var`;
 CREATE TABLE IF NOT EXISTS `limbo_thing_var` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `thing_id` varchar(12) NOT NULL,
+  `thing_id` varchar(18) NOT NULL,
   `key` varchar(256) NOT NULL,
   `type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 -- Data exporting was unselected.

--- a/sql/migrate/V100__Persistence.sql
+++ b/sql/migrate/V100__Persistence.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `list_element` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `thing` (
-  `p_id` varchar(12) NOT NULL,
+  `p_id` varchar(18) NOT NULL,
   `type` varchar(256) NOT NULL,
   `x` int DEFAULT NULL,
   `y` int DEFAULT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS `thing` (
 
 CREATE TABLE IF NOT EXISTS `thing_var` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `thing_id` varchar(12) NOT NULL,
+  `thing_id` varchar(18) NOT NULL,
   `key` varchar(256) NOT NULL,
   `type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS `limbo` (
   `type` varchar(64) NOT NULL,
   `p_ids` longtext NOT NULL,
   `metadata` varchar(64) DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   `metadata2` varchar(64) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4;
 
@@ -74,26 +74,26 @@ CREATE TABLE IF NOT EXISTS `limbo_list_element` (
   `key_type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
   `value_type` varchar(256) NOT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `limbo_thing` (
-  `p_id` varchar(12) NOT NULL,
+  `p_id` varchar(18) NOT NULL,
   `type` varchar(256) NOT NULL,
   `x` int DEFAULT NULL,
   `y` int DEFAULT NULL,
   `z` int DEFAULT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`p_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `limbo_thing_var` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `thing_id` varchar(12) NOT NULL,
+  `thing_id` varchar(18) NOT NULL,
   `key` varchar(256) NOT NULL,
   `type` varchar(256) NOT NULL,
   `value` longtext NOT NULL,
-  `limbo_assoc` varchar(12) NOT NULL,
+  `limbo_assoc` varchar(18) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Description of changes
Fixes PID collisions by adding two additional bytes to PIDs, moving our 50% collision chance from 70,000 items to 19,000,000. Makes the ``PERSISTENT_ID`` define generate the IDs directly, since using the uniqueness repository adds a miniscule amount of overhead for no real reason.

In the future, I'm open to simplifying the ID further