### PR TITLE
Decl saving improvements

### DIFF
--- a/mods/persistence/__defines/serializer.dm
+++ b/mods/persistence/__defines/serializer.dm
@@ -17,6 +17,7 @@
 #define SERIALIZER_TYPE_DATUM       "OBJ"
 #define SERIALIZER_TYPE_DATUM_FLAT  "FLAT_OBJ"
 #define SERIALIZER_TYPE_FLAT_REF    "FLAT_REF"
+#define SERIALIZER_TYPE_DECL        "DECL"
 
 /////////////////////////////////////////////////////////
 // SQL table names

--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -295,7 +295,6 @@
 #include "modules\world_save\wrappers\_wrapper_holder.dm"
 #include "modules\world_save\wrappers\area_wrapper.dm"
 #include "modules\world_save\wrappers\channel_wrapper.dm"
-#include "modules\world_save\wrappers\decl_wrapper.dm"
 #include "modules\world_save\wrappers\escrow_holder.dm"
 #include "modules\world_save\wrappers\image_wrapper.dm"
 #include "modules\world_save\wrappers\map_data_wrapper.dm"

--- a/mods/persistence/modules/world_save/serializers/json_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/json_serializer.dm
@@ -40,6 +40,9 @@
 			results[V] = "[SERIALIZER_TYPE_PATH]#[VV]"
 		else if(istext(VV) || isnum(VV) || isnull(VV))
 			results[V] = VV
+		else if(istype(VV, /decl))
+			var/decl/VD = VV
+			results[V] = "[SERIALIZER_TYPE_DECL]#[VD.type]"
 		else if(istype(VV, /datum))
 			if(should_flatten(VV))
 				if(VV in object_parent)
@@ -85,6 +88,9 @@
 			F_K = SerializeList(K, list_parent)
 		else if(istext(K) || isnum(K) || isnull(K))
 			F_K = K
+		else if(istype(K, /decl))
+			var/decl/KD = K
+			F_K = "[SERIALIZER_TYPE_DECL]#[KD.type]"
 		else if(ispath(K))
 			F_K = "[SERIALIZER_TYPE_PATH]#[K]"
 		else if(istype(K, /datum))
@@ -117,6 +123,9 @@
 				F_V = "[SERIALIZER_TYPE_PATH]#[V]"
 			else if(istext(V) || isnum(V) || isnull(V))
 				F_V = V
+			else if(istype(V, /decl))
+				var/decl/VD = V
+				F_V = "[SERIALIZER_TYPE_DECL]#[VD.type]"
 			else if(istype(V, /datum))
 				if(should_flatten(V))
 					if(V in list_parent)
@@ -158,6 +167,9 @@
 			if(findtext(encoded_value, "[SERIALIZER_TYPE_PATH]#", 1, 6))
 				thing.vars[V] = text2path(copytext(encoded_value, 6))
 				continue
+			if(findtext(encoded_value, "[SERIALIZER_TYPE_DECL]#", 1, 6))
+				thing.vars[V] = GET_DECL(text2path(copytext(encoded_value, 6)))
+				continue
 			if(findtext(encoded_value, "[SERIALIZER_TYPE_DATUM_FLAT]#", 1, 10))
 				// This is a flattened object.
 				thing.vars[V] = QueryAndDeserializeDatum(copytext(encoded_value, 10))
@@ -190,6 +202,8 @@
 				key = sql.QueryAndDeserializeDatum(copytext(K, 5))
 			else if(findtext(K, "[SERIALIZER_TYPE_PATH]#", 1, 6))
 				key = text2path(copytext(K, 6))
+			else if(findtext(K, "[SERIALIZER_TYPE_DECL]#", 1, 6))
+				key = GET_DECL(text2path(copytext(K, 6)))
 			else if(findtext(K, "[SERIALIZER_TYPE_DATUM_FLAT]#", 1, 10))
 				key = QueryAndDeserializeDatum(copytext(K, 10))
 			else if(findtext(K, "[SERIALIZER_TYPE_FLAT_REF]#", 1, 10))
@@ -211,6 +225,8 @@
 					V = sql.QueryAndDeserializeDatum(copytext(V, 5))
 				else if(findtext(V, "[SERIALIZER_TYPE_PATH]#", 1, 6))
 					V = text2path(copytext(V, 6))
+				else if(findtext(V, "[SERIALIZER_TYPE_DECL]#", 1, 6))
+					V = GET_DECL(text2path(copytext(V, 6)))
 				else if(findtext(V, "[SERIALIZER_TYPE_DATUM_FLAT]#", 1, 10))
 					V = QueryAndDeserializeDatum(copytext(V, 10))
 				else if(findtext(V, "[SERIALIZER_TYPE_FLAT_REF]#", 1, 10))

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -201,6 +201,10 @@ var/global/list/serialization_time_spent_type
 			VT = SERIALIZER_TYPE_FILE
 		else if (isnull(VV))
 			VT = SERIALIZER_TYPE_NULL
+		else if(istype(VV, /decl))
+			var/decl/VD = VV
+			VT = SERIALIZER_TYPE_DECL
+			VV = "[VD.type]"
 		else if(get_wrapper(VV))
 			VT = SERIALIZER_TYPE_WRAPPER
 			var/wrapper_path = get_wrapper(VV)
@@ -305,6 +309,10 @@ var/global/list/serialization_time_spent_type
 				KV = SERIALIZER_TYPE_LIST_EMPTY
 			else
 				KV = SerializeList(key)
+		else if(istype(key, /decl))
+			var/decl/key_d = key
+			KT = SERIALIZER_TYPE_DECL
+			KV = "[key_d.type]"
 		else if(get_wrapper(key))
 			KT = SERIALIZER_TYPE_WRAPPER
 			var/wrapper_path = get_wrapper(key)
@@ -351,6 +359,10 @@ var/global/list/serialization_time_spent_type
 					EV = SERIALIZER_TYPE_LIST_EMPTY
 				else
 					EV = SerializeList(EV)
+			else if(istype(EV, /decl))
+				var/decl/ED = EV
+				ET = SERIALIZER_TYPE_DECL
+				EV = "[ED.type]"
 			else if(get_wrapper(EV))
 				ET = SERIALIZER_TYPE_WRAPPER
 				var/wrapper_path = get_wrapper(EV)
@@ -442,6 +454,8 @@ var/global/list/serialization_time_spent_type
 					existing.vars[TV.key] = text2path(TV.value)
 				if(SERIALIZER_TYPE_NULL)
 					existing.vars[TV.key] = null
+				if(SERIALIZER_TYPE_DECL)
+					existing.vars[TV.key] = GET_DECL(text2path(TV.value))
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(TV.value)
 					existing.vars[TV.key] = GD.on_deserialize(src)
@@ -487,6 +501,8 @@ var/global/list/serialization_time_spent_type
 					key_value = text2num(LE.key)
 				if(SERIALIZER_TYPE_PATH)
 					key_value = text2path(LE.key)
+				if(SERIALIZER_TYPE_DECL)
+					key_value = GET_DECL(text2path(LE.key))
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(LE.key)
 					key_value = GD.on_deserialize(src)
@@ -513,6 +529,8 @@ var/global/list/serialization_time_spent_type
 					existing[key_value] = text2num(LE.value)
 				if(SERIALIZER_TYPE_PATH)
 					existing[key_value] = text2path(LE.value)
+				if(SERIALIZER_TYPE_DECL)
+					existing[key_value] = GET_DECL(text2path(LE.value))
 				if(SERIALIZER_TYPE_WRAPPER)
 					var/datum/wrapper/GD = flattener.QueryAndDeserializeDatum(LE.value)
 					existing[key_value] = GD.on_deserialize(src)

--- a/mods/persistence/modules/world_save/wrappers/decl_wrapper.dm
+++ b/mods/persistence/modules/world_save/wrappers/decl_wrapper.dm
@@ -1,8 +1,0 @@
-/datum/wrapper/decl
-	wrapper_for = /decl
-
-/datum/wrapper/decl/on_serialize(var/decl/D, var/serializer/curr_serializer)
-	key = "[D.type]"
-
-/datum/wrapper/decl/on_deserialize(var/serializer/curr_serializer)
-	return GET_DECL(text2path(key))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,7 @@ exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 10 ">> uses" '>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 42 "text2path uses" 'text2path'
+exactly 47 "text2path uses" 'text2path'
 exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 0 "goto uses" 'goto '
 exactly 7 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('


### PR DESCRIPTION
## Description of changes
Changes decl serialization to use a serializer type rather than a wrapper, directly converting the saved path to a decl on de-serialization

Depends on #477.

## Why and what will this PR improve
Decls are widespread enough (present on almost everything for materials) that it doesn't make sense to require the creation and flattening of a wrapper object for each one. Moving the logic to be internal to the serializers will improve performance and cleanliness.

## Authorship
Myself