### PR TITLE
Fixes the icon-path for 12g boxes

### DIFF
--- a/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_magazine/box/twelvegauge
 	name = "packet of generic 12g shells"
 	desc = "A packet of unsettlingly generic 12g shells."
-	icon_state = "box_12g1_slug"
+	icon_state = "12g1_slug"
 	icon = 'mods/persistence/icons/obj/ammunition/magazines.dmi'
 	material = /decl/material/solid/metal/steel
 	caliber = CALIBER_12G
@@ -11,19 +11,19 @@
 /obj/item/ammo_magazine/box/twelvegauge/slug
 	name = "packet of generic 12g slug shells"
 	desc = "A packet of unsettlingly generic 12g slug shells."
-	icon_state = "box_12g1_slug"
+	icon_state = "12g1_slug"
 	ammo_type = /obj/item/ammo_casing/twelvegauge/slug
 
 /obj/item/ammo_magazine/box/twelvegauge/buckshot
 	name = "packet of generic 12g buckshot shells"
 	desc = "A packet of unsettlingly generic 12g buckshot shells."
-	icon_state = "box_12g1_buckshot"
+	icon_state = "12g1_buckshot"
 	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot
 
 /obj/item/ammo_magazine/box/twelvegauge/slug/handmade
 	name = "packet of makeshift 12g slug shells"
 	desc = "Container of dubious origin intended for holding loose 12g slug shells."
-	icon_state = "box_12g0_slug"
+	icon_state = "12g0_slug"
 	origin_tech = "{'combat':1,'materials':1}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
@@ -34,7 +34,7 @@
 /obj/item/ammo_magazine/box/twelvegauge/buckshot/handmade
 	name = "packet of makeshift 12g buckshot shells"
 	desc = "Container of dubious origin intended for holding loose 12g buckshot shells."
-	icon_state = "box_12g0_buckshot"
+	icon_state = "12g0_buckshot"
 	origin_tech = "{'combat':1,'materials':1}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
@@ -45,7 +45,7 @@
 /obj/item/ammo_magazine/box/twelvegauge/slug/simple
 	name = "packet of standard 12g slug shells"
 	desc = "Container of ancient design intended for holding loose 12g slug shells."
-	icon_state = "box_12g1_slug"
+	icon_state = "12g1_slug"
 	origin_tech = "{'combat':2,'materials':2}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
@@ -57,7 +57,7 @@
 /obj/item/ammo_magazine/box/twelvegauge/buckshot/simple
 	name = "packet of standard 12g buckshot shells"
 	desc = "Container of ancient design intended for holding loose 12g buckshot shells."
-	icon_state = "box_12g1_buckshot"
+	icon_state = "12g1_buckshot"
 	origin_tech = "{'combat':2,'materials':2}"
 	material = /decl/material/solid/metal/steel
 	matter = list(


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Quick change that makes 12g boxes actually use the sprites that they ought to be using

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes 12g boxes not invisible. Very good.

## Authorship
<!-- Describe original authors of changes to credit them. -->
genessee did this

## Changelog
:cl:
bugfix: 12-gauge ammunition boxes are no longer invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->