### PR TITLE
Temporarily disable clothing contamination from chlorine exposure

### DIFF
--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -5,7 +5,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 	var/CONTAMINANT_DMG_NAME = "Contaminant Damage Amount"
 	var/CONTAMINANT_DMG_DESC = "Self Descriptive"
 
-	var/CLOTH_CONTAMINATION = 1
+	var/CLOTH_CONTAMINATION = 0
 	var/CLOTH_CONTAMINATION_NAME = "Cloth Contamination"
 	var/CLOTH_CONTAMINATION_DESC = "If this is on, contaminants do damage by getting into cloth."
 

--- a/code/modules/ZAS/Variable Settings.dm
+++ b/code/modules/ZAS/Variable Settings.dm
@@ -195,7 +195,7 @@ var/global/vs_control/vsc = new
 		return
 	switch(def)
 		if("Contaminants - Standard")
-			contaminant_control.CLOTH_CONTAMINATION = 1 //If this is on, contaminants do damage by getting into cloth.
+			contaminant_control.CLOTH_CONTAMINATION = 0 //If this is on, contaminants do damage by getting into cloth.
 			contaminant_control.STRICT_PROTECTION_ONLY = 0
 			contaminant_control.GENETIC_CORRUPTION = 0 //Chance of genetic corruption as well as toxic damage, X in 1000.
 			contaminant_control.SKIN_BURNS = 0       //Contaminants have an effect similar to mustard gas on the un-suited.


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Disables clothing getting the 'contamination' status when exposed to chlorine gas, due to contamination being really hard to remove and being finnicky with suits.

Nata said they were also working on a better fix, but this can work as a quick, easily revertable (read: change 0 to 1) stopgap until a better fix is made.

This doesn't prevent any other kind of damage from exposure to chlorine gas, like eye damage or massive tox damage if unprotected; only the lingering 'contaminated' status is removed.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right now, the contaminated status is incredibly annoying and unfun to deal with. It can only be removed with detergent and a washing machine - no other way - and can't ever be removed from non-clothing items since they can't be crammed in a washing machine in the first place.

Nata said they'll work on a better fix, as previously mentioned, but this one works as a stopgap until that better fix comes.

## Authorship
<!-- Describe original authors of changes to credit them. -->
genessee

## Changelog
:cl:
tweak: Disabled clothing contamination
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->