### PR TITLE
Fixes design copying

### DIFF
--- a/mods/persistence/modules/science/files/design.dm
+++ b/mods/persistence/modules/science/files/design.dm
@@ -336,6 +336,10 @@
 		return
 	copy.recipe = recipe
 	copy.is_copy = TRUE
+	copy.finalized = TRUE
+
+	copy.stored_data += " This design appears to be a copy of the original, and cannot be copied further."
+
 	return copy
 
 #undef MAX_THEORIES


### PR DESCRIPTION
Fixes design files not being set as finalized when copied. Also adds an explanatory string for why design files cannot be copied further.

This is somewhat of a stop gap fix, and I'd like to improve design files more in general.