### PR TITLE
Stopgap exterior turf load fix

### DIFF
--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -21,6 +21,7 @@
 #include "controllers\atoms.dm"
 #include "controllers\autotransfer.dm"
 #include "controllers\ticker.dm"
+#include "controllers\subsystems\air.dm"
 #include "controllers\subsystems\autosave.dm"
 #include "controllers\subsystems\mapping.dm"
 #include "controllers\subsystems\mining.dm"

--- a/mods/persistence/controllers/subsystems/air.dm
+++ b/mods/persistence/controllers/subsystems/air.dm
@@ -1,0 +1,14 @@
+// TODO: Solve this issue properly
+// On load, we check turfs which have been marked for update and cull any which are outside. What's likely happening is they're being marked for update before
+// all z-levels are initialized, but it will take some time to track this down
+/datum/controller/subsystem/air/proc/cull_updated_turfs()
+
+	var/list/new_tiles_to_update = list()
+
+	var/list/curr_tiles = tiles_to_update
+	for(var/turf/T as anything in curr_tiles)
+		if(SHOULD_PARTICIPATE_IN_ZONES(T))
+			new_tiles_to_update += T
+
+	tiles_to_update.Cut()
+	tiles_to_update = new_tiles_to_update

--- a/mods/persistence/controllers/subsystems/mapping.dm
+++ b/mods/persistence/controllers/subsystems/mapping.dm
@@ -14,6 +14,9 @@
 				PRINT_STACK_TRACE("Missing z-level data object for loaded z[num2text(z)]!")
 			level.setup_level_data(TRUE)
 		report_progress_serializer("Finished setting up level data for loaded z-levels!")
+
+		// Stopgap fix. We do this here rather than in SSair.Initialize because SSair may be rebooted.
+		SSair.cull_updated_turfs()
 	else
 		report_progress_serializer("No existing save found. Loading from map files..")
 #else


### PR DESCRIPTION
## Description of changes
Currently, turfs that should not participate in ZAS are marked for update on load. I'm not sure when this occurs, but it will take some time to figure out. This stopgap fix culls the turf update list prior to air Initialization, temporarily fixing the issue. The impact on startup time is pretty slight.