### PR TITLE
Fixes 'empty' variant of pocket pistol

### DIFF
--- a/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
+++ b/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
@@ -17,7 +17,7 @@
 	path = /obj/item/gun/projectile/bolt_action/simple/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/pistol_pocket
-	path = /obj/item/gun/projectile/pistol_pocket/simple/empty
+	path = /obj/item/gun/projectile/pistol/pistol_pocket/simple/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/pistol
 	path = /obj/item/gun/projectile/pistol/simple/empty
@@ -53,7 +53,7 @@
 	path = /obj/item/gun/projectile/bolt_action/advanced/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/pistol_pocket
-	path = /obj/item/gun/projectile/pistol_pocket/advanced/empty
+	path = /obj/item/gun/projectile/pistol/pistol_pocket/advanced/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/pistol
 	path = /obj/item/gun/projectile/pistol/advanced/empty

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
@@ -18,5 +18,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/pistol_pocket/simple/empty
+/obj/item/gun/projectile/pistol/pistol_pocket/simple/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
@@ -23,5 +23,5 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=2, one_hand_penalty=1, burst_accuracy=list(1,0,-1),       dispersion=list(0.0, 1.6, 2.4, 2.4)),
 	)
 
-/obj/item/gun/projectile/pistol_pocket/advanced/empty
+/obj/item/gun/projectile/pistol/pistol_pocket/advanced/empty
 	starts_loaded = FALSE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
'Empty' pocket pistols didn't get their atompaths updated when I fixed the main one, oops

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
'Empty' pocket pistols now work correctly

## Authorship
<!-- Describe original authors of changes to credit them. -->
me

## Changelog
:cl:
tweak: Pocket pistols printed via protolathe perform properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->