### PR TITLE
re-add client preferences to the character panel

### DIFF
--- a/mods/persistence/modules/client/preference_setup/preference_setup.dm
+++ b/mods/persistence/modules/client/preference_setup/preference_setup.dm
@@ -1,10 +1,8 @@
 /datum/category_collection/player_setup_collection
 	var/static/list/hidden_categories = list(\
-		/datum/category_group/player_setup_category/appearance_preferences,\
-		/datum/category_group/player_setup_category/occupation_preferences,\
-		/datum/category_group/player_setup_category/record_preferences, \
-		/datum/category_group/player_setup_category/controls,\
-		/datum/category_group/player_setup_category/global_preferences,\
+		/datum/category_group/player_setup_category/appearance_preferences,
+		/datum/category_group/player_setup_category/occupation_preferences,
+		/datum/category_group/player_setup_category/record_preferences,
 	)
 
 /datum/category_collection/player_setup_collection/header()


### PR DESCRIPTION
## Description of changes
Client preferences were hidden from the menu for whatever reasons.

## Changelog
:cl:
bugfix: fixed client preferences not showing up on the character panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->