### PR TITLE
Repath volcanic turfs to match upstream changes

### DIFF
--- a/maps/outreach/outreach-1.dmm
+++ b/maps/outreach/outreach-1.dmm
@@ -4,10 +4,10 @@
 /area/exoplanet/outreach/underground/d2)
 "ab" = (
 /obj/effect/mine/kick,
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/d2)
 "ac" = (
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/d2)
 "ad" = (
 /obj/structure/cable/yellow{
@@ -1442,7 +1442,7 @@
 /area/outreach/outpost/hallway/central/basement2)
 "do" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/d2)
 "dp" = (
 /obj/structure/cable/yellow{
@@ -1553,7 +1553,7 @@
 /obj/machinery/geothermal{
 	dir = 8
 	},
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/outreach/outpost/engineering/b2/geothermals)
 "dz" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -1674,7 +1674,7 @@
 /obj/machinery/geothermal{
 	dir = 4
 	},
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/outreach/outpost/engineering/b2/geothermals)
 "dL" = (
 /obj/structure/cable/yellow{
@@ -3110,7 +3110,7 @@
 /area/outreach/outpost/hallway/west/basement2)
 "gC" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/outreach/outpost/engineering/b2/geothermals)
 "gD" = (
 /obj/structure/cable/yellow{
@@ -4311,7 +4311,7 @@
 /area/outreach/outpost/stairwell/basement2)
 "je" = (
 /obj/effect/geyser,
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/d2)
 "jf" = (
 /turf/exterior/wall/outreach/abyss,
@@ -5069,7 +5069,7 @@
 "kH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/d2)
 "kI" = (
 /obj/effect/floor_decal/industrial/fire/corner,

--- a/maps/outreach/outreach-3.dmm
+++ b/maps/outreach/outreach-3.dmm
@@ -1000,11 +1000,6 @@
 "cB" = (
 /turf/simulated/wall/concrete,
 /area/outreach/outpost/maint/power/ground)
-"cC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_grid,
-/area/outreach/outpost/eva/gf/north)
 "cE" = (
 /obj/machinery/light_switch{
 	icon_state = "light0";
@@ -1999,6 +1994,10 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/outreach/outpost/hallway/south/ground/business_wing)
+"gM" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_grid,
+/area/outreach/outpost/eva/gf/south)
 "gN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	icon_state = "map_vent_out";
@@ -2197,6 +2196,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete,
 /area/exoplanet/outreach)
+"ic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_grid,
+/area/outreach/outpost/eva/gf/north)
 "id" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -2806,10 +2810,6 @@
 "mb" = (
 /turf/exterior/water/outreach,
 /area/exoplanet/outreach)
-"me" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_grid,
-/area/outreach/outpost/eva/gf/south)
 "mh" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "stripe";
@@ -30461,7 +30461,7 @@ Cc
 mZ
 ul
 Eg
-cC
+ic
 aK
 aQ
 hs
@@ -30473,7 +30473,7 @@ PQ
 SG
 ka
 Nv
-me
+gM
 IC
 yQ
 vP

--- a/maps/outreach/outreach_exoplanet.dm
+++ b/maps/outreach/outreach_exoplanet.dm
@@ -77,7 +77,7 @@
 	iterations = 5
 	descriptor = "outreach abyssal caves"
 	wall_type =  /turf/exterior/wall/outreach/abyss
-	floor_type = /turf/exterior/volcanic/mining/outreach/abyss
+	floor_type = /turf/exterior/rock/volcanic/mining/outreach/abyss
 	mineral_turf = /turf/exterior/wall/random/outreach/abyss
 
 /datum/random_map/automata/cave_system/outreach/subterrane
@@ -91,7 +91,7 @@
 	iterations = 5
 	descriptor = "outreach mountain caves"
 	wall_type =  /turf/exterior/wall/outreach/mountain
-	floor_type = /turf/exterior/volcanic/mining
+	floor_type = /turf/exterior/rock/volcanic/mining
 	mineral_turf = /turf/exterior/wall/random/outreach/mountain
 
 //////////////////////////////////////////////////////////////////////////

--- a/maps/outreach/outreach_south-1.dmm
+++ b/maps/outreach/outreach_south-1.dmm
@@ -45,7 +45,7 @@
 /turf/unsimulated/rock,
 /area/exoplanet/outreach/underground)
 "ak" = (
-/turf/exterior/volcanic/mining/outreach/abyss,
+/turf/exterior/rock/volcanic/mining/outreach/abyss,
 /area/exoplanet/outreach/underground/mines/access/b2)
 "al" = (
 /obj/structure/stairs/long/east,
@@ -144,7 +144,7 @@
 /turf/simulated/floor/plating/outreach,
 /area/exoplanet/outreach/underground/mines/access/b2)
 "ax" = (
-/turf/exterior/volcanic/outreach/abyss,
+/turf/exterior/rock/volcanic/outreach/abyss,
 /area/exoplanet/outreach/underground/mines/access/b2)
 "ay" = (
 /turf/exterior/wall/random/outreach/abyss,

--- a/maps/outreach/outreach_turfs.dm
+++ b/maps/outreach/outreach_turfs.dm
@@ -143,7 +143,7 @@
 	color          = "#d9c179"
 	open_turf_type = /turf/exterior/open
 
-/turf/exterior/volcanic/mining/outreach/abyss
+/turf/exterior/rock/volcanic/mining/outreach/abyss
 	open_turf_type = /turf/exterior/open
 
 //Mining Walls
@@ -157,7 +157,7 @@
 
 /turf/exterior/wall/random/outreach/abyss
 	material   = /decl/material/solid/stone/slate
-	floor_type = /turf/exterior/volcanic/mining/outreach/abyss
+	floor_type = /turf/exterior/rock/volcanic/mining/outreach/abyss
 
 ///////////////////////////////////////////////////////////////////////////////////
 // Surface Turfs
@@ -181,7 +181,7 @@
 	reagent_type   = /decl/material/liquid/acid/hydrochloric
 	open_turf_type = /turf/exterior/chlorine_sand/outreach //Don't allow just removing this easily
 
-/turf/exterior/volcanic/outreach/abyss
+/turf/exterior/rock/volcanic/outreach/abyss
 	open_turf_type = /turf/simulated/magma
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/maps/outreach/outreach_zlevels.dm
+++ b/maps/outreach/outreach_zlevels.dm
@@ -46,7 +46,7 @@
 /datum/level_data/planetoid/outreach/underground/abyss
 	name             = "Outreach Depths"
 	level_id         = OUTREACH_LEVEL_ID_ABYSS
-	base_turf        = /turf/exterior/volcanic/outreach/abyss
+	base_turf        = /turf/exterior/rock/volcanic/outreach/abyss
 	base_area        = /area/exoplanet/outreach/underground/d2
 	connected_levels = list(
 		OUTREACH_LEVEL_ID_UNDERGROUND = UP,
@@ -61,7 +61,7 @@
 	level_id         = OUTREACH_LEVEL_ID_SOUTH_ABYSS
 	level_flags      = ZLEVEL_CONTACT | ZLEVEL_PLAYER | ZLEVEL_MINING | ZLEVEL_SAVED | ZLEVEL_SEALED
 	level_gen_type   = /datum/random_map/automata/cave_system/outreach/abyss
-	base_turf        = /turf/exterior/volcanic/mining/outreach/abyss
+	base_turf        = /turf/exterior/rock/volcanic/mining/outreach/abyss
 	base_area        = /area/exoplanet/outreach/underground/mines/b2
 	connected_levels = list(
 		OUTREACH_LEVEL_ID_SOUTH_UNDERGROUND = UP,

--- a/mods/persistence/controllers/subsystems/mining.dm
+++ b/mods/persistence/controllers/subsystems/mining.dm
@@ -1,5 +1,4 @@
 /turf/exterior/barren/mining
-/turf/exterior/volcanic/mining
 
 /datum/random_map/automata/cave_system/outreach
 	floor_type = /turf/exterior/barren/mining


### PR DESCRIPTION
## Description of changes
Volcanic turfs had their type path changed upstream, which caused the turfs overriding the type to have the wrong appearance on outreach.

## Changelog
:cl:
bugfix: fixed volcanic turfs on outreach having the wrong icon and properties.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->