### PR TITLE
Multi-tile saving fix

### DIFF
--- a/mods/persistence/_persistence.dme
+++ b/mods/persistence/_persistence.dme
@@ -201,6 +201,7 @@
 #include "modules\modular_computers\networking\machines\area_controller.dm"
 #include "modules\modular_computers\networking\machines\telecomms.dm"
 #include "modules\multiz\level_data.dm"
+#include "modules\multiz\stairs.dm"
 #include "modules\organs\organs.dm"
 #include "modules\organs\external\_external_saving.dm"
 #include "modules\organs\external\head.dm"

--- a/mods/persistence/controllers/subsystems/persistence/persistence_loading.dm
+++ b/mods/persistence/controllers/subsystems/persistence/persistence_loading.dm
@@ -147,7 +147,7 @@
 
 ///Runs after deserialize on all the loaded atoms.
 /datum/controller/subsystem/persistence/proc/_run_after_deserialize()
-	//Run after_deserialize on all atoms in the map.
+	//Run after_deserialize on all datums deserialized.
 	for(var/id in serializer.reverse_map)
 		var/datum/T
 		try
@@ -155,35 +155,6 @@
 			T.after_deserialize()
 		catch(var/exception/e)
 			_handle_recoverable_load_exception(e, "while running after_deserialize() on PID: '[id]'[!isnull(T)? ", '[T]'(\ref[T])([T.type])" : ""]")
-
-	//Since datums used as list value and list key are stored in another list, run after_deserialize() on them too
-	for(var/id in serializer.reverse_list_map)
-		var/list/_list
-		try
-			_list = serializer.reverse_list_map[id]
-			//#FIXME: If the keys in the list are numbers, this will be even slower than it is right now.
-			//        Since it'll runtime if a number is out of range of the list.
-			for(var/key in _list)
-				var/datum/K = key
-				if(istype(K, /datum))
-					try
-						K.after_deserialize()
-					catch(var/exception/e_list_key)
-						_handle_recoverable_load_exception(e_list_key, "while running after_deserialize() on key [__PRINT_KEY_DETAIL(K)], of list: [__PRINT_STRING_LIST_DETAIL(id, _list)]")
-
-				var/datum/V
-				try
-					V = _list[key] //#FIXME: We really need to get rid of this awful way to check list types.
-				catch
-					continue
-				if(istype(V, /datum))
-					try
-						V.after_deserialize()
-					catch(var/exception/e_list_value)
-						_handle_recoverable_load_exception(e_list_value, "while running after_deserialize() on value [__PRINT_VALUE_DETAIL(V)], for key [__PRINT_KEY_DETAIL(K)], of list: [__PRINT_STRING_LIST_DETAIL(id, _list)]")
-		catch(var/exception/e_list)
-			//Catch any sort of bad index error
-			_handle_recoverable_load_exception(e_list, "while running after_deserialize() on elements of list: [__PRINT_STRING_LIST_DETAIL(id, _list)]")
 
 ///Clean up limbo by removing any characters present in the gameworld. This may occur if the server does not save after
 ///a player enters limbo.

--- a/mods/persistence/modules/multiz/stairs.dm
+++ b/mods/persistence/modules/multiz/stairs.dm
@@ -1,10 +1,10 @@
-/obj/machinery/door/airlock/double/before_save()
+/obj/structure/stairs/long/before_save()
 	. = ..()
 	if(isturf(loc))
 		var/turf/T = loc
 		CUSTOM_SV("primary_loc", "[T.x],[T.y],[T.z]")
 
-/obj/machinery/door/airlock/double/after_deserialize()
+/obj/structure/stairs/long/after_deserialize()
 	var/primary_loc_coords = LOAD_CUSTOM_SV("primary_loc")
 	var/list/coords = splittext(primary_loc_coords, ",")
 	if(!islist(coords) || length(coords) < 3)

--- a/mods/persistence/modules/world_save/serializers/sql_serializer.dm
+++ b/mods/persistence/modules/world_save/serializers/sql_serializer.dm
@@ -126,12 +126,6 @@ var/global/list/serialization_time_spent_type
 #endif
 		return existing
 
-	//locs check, to make sure we're saving a multi-tile object only on its original turf
-	if(isturf(object_parent) && ismovable(object))
-		var/atom/movable/am = object
-		if(length(am.locs) > 1 && (am.loc != object_parent))
-			return
-
 	var/time_before_serialize = REALTIMEOFDAY
 	// Thing didn't exist. Create it.
 	var/p_i = object.persistent_id ? object.persistent_id : PERSISTENT_ID
@@ -334,7 +328,7 @@ var/global/list/serialization_time_spent_type
 				KV = flattener.SerializeDatum(KV)
 			else
 				KT = SERIALIZER_TYPE_DATUM
-				KV = SerializeDatum(KV)
+				KV = SerializeDatum(KV, list_parent)
 		else
 #ifdef SAVE_DEBUG
 			to_world_log("(SerializeListElem-Skip) Unknown Key. Value: [key]")
@@ -381,7 +375,7 @@ var/global/list/serialization_time_spent_type
 					EV = flattener.SerializeDatum(EV)
 				else
 					ET = SERIALIZER_TYPE_DATUM
-					EV = SerializeDatum(EV)
+					EV = SerializeDatum(EV, list_parent)
 			else
 				// Don't know what this is. Skip it.
 #ifdef SAVE_DEBUG


### PR DESCRIPTION
## Description of changes
Fixes multi-tile objects saving by adding some bespoke code to stairs and double doors. By necessity, we need to use coordinate location since direct references to tiles is inconsistent.

While I was fixing this, I also added a couple missing ``object_parent`` arguments during serialization. I also realized that we've been calling ``after_deserialize`` at least twice on nearly everything. This is because the code which called ``after_deserialize`` assumed that datums serialized as list entries were not included in the ``reverse_map``. This isn't true, and hasn't been for years if it has at all, so I fixed that.

Closes #421 

## Authorship
Myself. Thanks to PsyCommando for helpful discussions.