### PR TITLE
Fix cheap pickaxe icon not having handle

### DIFF
--- a/mods/persistence/modules/chargen/items.dm
+++ b/mods/persistence/modules/chargen/items.dm
@@ -38,6 +38,8 @@
 	matter = list(
 		/decl/material/solid/metal/iron/r_styrofoam = MATTER_AMOUNT_TRACE
 	)
+	build_from_parts = TRUE
+	hardware_color = COLOR_SILVER
 
 /obj/item/flashlight/lantern/cheap
 	name = "cheap lantern"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The cheap pickaxe now has a handle. Should still be green-ish due to 'color' sitting on top of 'hardware_color'

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfix

## Authorship
<!-- Describe original authors of changes to credit them. -->
genessee

## Changelog
:cl:
bugfix: Cheap pickaxe now has a proper handle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->