### PR TITLE
Assortment of Gun Overhaul fixes and QOL changes

### DIFF
--- a/mods/persistence/modules/fabrication/designs/protolathe/designs_ammunition.dm
+++ b/mods/persistence/modules/fabrication/designs/protolathe/designs_ammunition.dm
@@ -1,83 +1,83 @@
 /datum/fabricator_recipe/protolathe/ammunition/fivefiftysix/magazine/tier0
-	path = /obj/item/ammo_magazine/fivefiftysix/handmade
+	path = /obj/item/ammo_magazine/fivefiftysix/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/fivefiftysix/box/tier0
-	path = /obj/item/ammo_magazine/box_fivefiftysix/handmade
+	path = /obj/item/ammo_magazine/box_fivefiftysix/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/fivefiftysix/magazine/tier1
-	path = /obj/item/ammo_magazine/fivefiftysix/simple
+	path = /obj/item/ammo_magazine/fivefiftysix/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/fivefiftysix/box/tier1
-	path = /obj/item/ammo_magazine/box_fivefiftysix/simple
+	path = /obj/item/ammo_magazine/box_fivefiftysix/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/magazine/tier0
-	path = /obj/item/ammo_magazine/twentytwolr/handmade
+	path = /obj/item/ammo_magazine/twentytwolr/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/box/tier0
-	path = /obj/item/ammo_magazine/box_twentytwolr/handmade
+	path = /obj/item/ammo_magazine/box_twentytwolr/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/magazine/tier1
-	path = /obj/item/ammo_magazine/twentytwolr/simple
+	path = /obj/item/ammo_magazine/twentytwolr/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/box/tier1
-	path = /obj/item/ammo_magazine/box_twentytwolr/simple
+	path = /obj/item/ammo_magazine/box_twentytwolr/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/magazine/tier0
-	path = /obj/item/ammo_magazine/fortyfive/handmade
+	path = /obj/item/ammo_magazine/fortyfive/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/box/tier0
-	path = /obj/item/ammo_magazine/box_fortyfive/handmade
+	path = /obj/item/ammo_magazine/box_fortyfive/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/magazine/tier1
-	path = /obj/item/ammo_magazine/fortyfive/simple
+	path = /obj/item/ammo_magazine/fortyfive/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/box/tier1
-	path = /obj/item/ammo_magazine/box_fortyfive/simple
+	path = /obj/item/ammo_magazine/box_fortyfive/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/slug/tier0
-	path = /obj/item/ammo_magazine/box_twelvegauge/slug/handmade
+	path = /obj/item/ammo_magazine/box_twelvegauge/slug/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/buckshot/tier0
-	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/handmade
+	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/slug/tier1
-	path = /obj/item/ammo_magazine/box_twelvegauge/slug/simple
+	path = /obj/item/ammo_magazine/box_twelvegauge/slug/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/buckshot/tier1
-	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/simple
+	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/magazine/tier0
-	path = /obj/item/ammo_magazine/threefiftyseven/handmade
+	path = /obj/item/ammo_magazine/threefiftyseven/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/box/tier0
-	path = /obj/item/ammo_magazine/box_threefiftyseven/handmade
+	path = /obj/item/ammo_magazine/box_threefiftyseven/tierzero
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/magazine/tier1
-	path = /obj/item/ammo_magazine/threefiftyseven/simple
+	path = /obj/item/ammo_magazine/threefiftyseven/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/box/tier1
-	path = /obj/item/ammo_magazine/box_threefiftyseven/simple
+	path = /obj/item/ammo_magazine/box_threefiftyseven/tierone
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/magazine/tier2
-	path = /obj/item/ammo_magazine/threefiftyseven/advanced
+	path = /obj/item/ammo_magazine/threefiftyseven/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/threefiftyseven/box/tier2
-	path = /obj/item/ammo_magazine/box_threefiftyseven/advanced
+	path = /obj/item/ammo_magazine/box_threefiftyseven/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/slug/tier2
-	path = /obj/item/ammo_magazine/box_twelvegauge/slug/advanced
+	path = /obj/item/ammo_magazine/box_twelvegauge/slug/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/twelvegauge/box/buckshot/tier2
-	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/advanced
+	path = /obj/item/ammo_magazine/box_twelvegauge/buckshot/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/magazine/tier2
-	path = /obj/item/ammo_magazine/twentytwolr/advanced
+	path = /obj/item/ammo_magazine/twentytwolr/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/twentytwolr/box/tier2
-	path = /obj/item/ammo_magazine/box_twentytwolr/advanced
+	path = /obj/item/ammo_magazine/box_twentytwolr/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/magazine/tier2
-	path = /obj/item/ammo_magazine/fortyfive/advanced
+	path = /obj/item/ammo_magazine/fortyfive/tiertwo
 
 /datum/fabricator_recipe/protolathe/ammunition/fortyfive/box/tier2
-	path = /obj/item/ammo_magazine/box_fortyfive/advanced
+	path = /obj/item/ammo_magazine/box_fortyfive/tiertwo

--- a/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
+++ b/mods/persistence/modules/fabrication/designs/protolathe/designs_weapons.dm
@@ -1,68 +1,68 @@
 /datum/fabricator_recipe/protolathe/weapon/tier0/bolt_action
-	path = /obj/item/gun/projectile/bolt_action/handmade/empty
+	path = /obj/item/gun/projectile/bolt_action/tierzero/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier0/revolver
-	path = /obj/item/gun/projectile/revolver/handmade/empty
+	path = /obj/item/gun/projectile/revolver/tierzero/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier0/pistol
-	path = /obj/item/gun/projectile/pistol/handmade/empty
+	path = /obj/item/gun/projectile/pistol/tierzero/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier0/shotgun
-	path = /obj/item/gun/projectile/shotgun/handmade/empty
+	path = /obj/item/gun/projectile/shotgun/tierzero/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier0/laser_rifle
-	path = /obj/item/gun/energy/laser/rifle/handmade
+	path = /obj/item/gun/energy/laser/rifle/tierzero
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/bolt_action
-	path = /obj/item/gun/projectile/bolt_action/simple/empty
+	path = /obj/item/gun/projectile/bolt_action/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/pistol_pocket
-	path = /obj/item/gun/projectile/pistol/pistol_pocket/simple/empty
+	path = /obj/item/gun/projectile/pistol/pistol_pocket/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/pistol
-	path = /obj/item/gun/projectile/pistol/simple/empty
+	path = /obj/item/gun/projectile/pistol/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/pistol_golden
-	path = /obj/item/gun/projectile/pistol/simple/golden/empty
+	path = /obj/item/gun/projectile/pistol/tierone/golden/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/revolver
-	path = /obj/item/gun/projectile/revolver/simple/empty
+	path = /obj/item/gun/projectile/revolver/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_double
-	path = /obj/item/gun/projectile/shotgun/simple/empty
+	path = /obj/item/gun/projectile/shotgun/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_double_sawn
-	path = /obj/item/gun/projectile/shotgun/simple/sawnoff/empty
+	path = /obj/item/gun/projectile/shotgun/tierone/sawnoff/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/shotgun_pump
-	path = /obj/item/gun/projectile/shotgun/pump/simple/empty
+	path = /obj/item/gun/projectile/shotgun/pump/tierone/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/laser_rifle
-	path = /obj/item/gun/energy/laser/rifle/simple
+	path = /obj/item/gun/energy/laser/rifle/tierone
 
 /datum/fabricator_recipe/protolathe/weapon/tier1/laser_pistol
-	path = /obj/item/gun/energy/laser/pistol/simple
+	path = /obj/item/gun/energy/laser/pistol/tierone
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/laser_rifle
-	path = /obj/item/gun/energy/laser/rifle/advanced
+	path = /obj/item/gun/energy/laser/rifle/tiertwo
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/laser_pistol
-	path = /obj/item/gun/energy/laser/pistol/advanced
+	path = /obj/item/gun/energy/laser/pistol/tiertwo
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/bolt_action
-	path = /obj/item/gun/projectile/bolt_action/advanced/empty
+	path = /obj/item/gun/projectile/bolt_action/tiertwo/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/pistol_pocket
-	path = /obj/item/gun/projectile/pistol/pistol_pocket/advanced/empty
+	path = /obj/item/gun/projectile/pistol/pistol_pocket/tiertwo/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/pistol
-	path = /obj/item/gun/projectile/pistol/advanced/empty
+	path = /obj/item/gun/projectile/pistol/tiertwo/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/revolver
-	path = /obj/item/gun/projectile/revolver/advanced/empty
+	path = /obj/item/gun/projectile/revolver/tiertwo/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/smg
-	path = /obj/item/gun/projectile/automatic/smg/advanced/empty
+	path = /obj/item/gun/projectile/automatic/smg/tiertwo/empty
 
 /datum/fabricator_recipe/protolathe/weapon/tier2/shotgun_pump
-	path = /obj/item/gun/projectile/shotgun/pump/advanced/empty
+	path = /obj/item/gun/projectile/shotgun/pump/tiertwo/empty

--- a/mods/persistence/modules/projectiles/ammunition/12g/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/12g/bullets.dm
@@ -33,72 +33,72 @@
 	range_step = 1
 	spread_step = 10
 
-/obj/item/ammo_casing/twelvegauge/slug/handmade
+/obj/item/ammo_casing/twelvegauge/slug/tierzero
 	name = "makeshift 12g slug shell"
 	desc = "12g slug shell of dubious origin. Sports decent armor penetration capabilities and high damage, but suffers from poor range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier0_slug.dmi'
-	projectile_type = /obj/item/projectile/bullet/twelvegauge/handmade
+	projectile_type = /obj/item/projectile/bullet/twelvegauge/tierzero
 
-/obj/item/projectile/bullet/twelvegauge/handmade
+/obj/item/projectile/bullet/twelvegauge/tierzero
 	damage = 40
 	distance_falloff = 5
 	penetration_modifier = 1.1
 
-/obj/item/ammo_casing/twelvegauge/buckshot/handmade
+/obj/item/ammo_casing/twelvegauge/buckshot/tierzero
 	name = "makeshift 12g buckshot shell"
 	desc = "12g buckshot shell of dubious origin. Sports high damage, but suffers from poor armor penetration and very poor range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier0_buckshot.dmi'
-	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/handmade
+	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/tierzero
 
-/obj/item/projectile/bullet/pellet/twelvegauge/handmade
+/obj/item/projectile/bullet/pellet/twelvegauge/tierzero
 	damage = 10
 	pellets = 6
 	range_step = 1
 	spread_step = 10
 	penetration_modifier = 1.5
 
-/obj/item/ammo_casing/twelvegauge/slug/simple
+/obj/item/ammo_casing/twelvegauge/slug/tierone
 	name = "standard 12g slug shell"
 	desc = "12g slug shell of ancient design. Sports decent armor penetration capabilities and high damage, but suffers from poor range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier1_slug.dmi'
-	projectile_type = /obj/item/projectile/bullet/twelvegauge/simple
+	projectile_type = /obj/item/projectile/bullet/twelvegauge/tierone
 
-/obj/item/projectile/bullet/twelvegauge/simple
+/obj/item/projectile/bullet/twelvegauge/tierone
 	damage = 60
 	distance_falloff = 5
 	penetration_modifier = 0.9
 
-/obj/item/ammo_casing/twelvegauge/buckshot/simple
+/obj/item/ammo_casing/twelvegauge/buckshot/tierone
 	name = "standard 12g buckshot shell"
 	desc = "12g buckshot shell of ancient design. Sports high damage, but suffers from poor armor penetration and very poor range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier1_buckshot.dmi'
-	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/simple
+	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/tierone
 
-/obj/item/projectile/bullet/pellet/twelvegauge/simple
+/obj/item/projectile/bullet/pellet/twelvegauge/tierone
 	damage = 15
 	pellets = 6
 	range_step = 1
 	spread_step = 10
 	penetration_modifier = 1.3
 
-/obj/item/ammo_casing/twelvegauge/slug/advanced
+/obj/item/ammo_casing/twelvegauge/slug/tiertwo
 	name = "advanced 12g slug shell"
 	desc = "12g slug shell of modern design. Sports good armor penetration capabilities and very high damage, but suffers from unimpressive range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier2_slug.dmi'
-	projectile_type = /obj/item/projectile/bullet/twelvegauge/advanced
+	projectile_type = /obj/item/projectile/bullet/twelvegauge/tiertwo
 
-/obj/item/projectile/bullet/twelvegauge/advanced
+/obj/item/projectile/bullet/twelvegauge/tiertwo
 	damage = 70
 	distance_falloff = 4
 	penetration_modifier = 0.85
 
-/obj/item/ammo_casing/twelvegauge/buckshot/advanced
+/obj/item/ammo_casing/twelvegauge/buckshot/tiertwo
 	name = "advanced 12g buckshot shell"
 	desc = "12g buckshot shell of modern design. Sports incredibly high damage, but suffers from poor armor penetration and poor range."
 	icon = 'mods/persistence/icons/obj/ammunition/12g/tier2_buckshot.dmi'
-	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/advanced
+	projectile_type = /obj/item/projectile/bullet/pellet/twelvegauge/tiertwo
 
-/obj/item/projectile/bullet/pellet/twelvegauge/advanced
+/obj/item/projectile/bullet/pellet/twelvegauge/tiertwo
 	damage = 20
 	pellets = 6
 	range_step = 1

--- a/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
@@ -20,7 +20,7 @@
 	icon_state = "box_12g1_buckshot"
 	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot
 
-/obj/item/ammo_magazine/box_twelvegauge/slug/handmade
+/obj/item/ammo_magazine/box_twelvegauge/slug/tierzero
 	name = "packet of makeshift 12g slug shells"
 	desc = "Container of dubious origin intended for holding loose 12g slug shells."
 	icon_state = "box_12g0_slug"
@@ -29,9 +29,9 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/handmade
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tierzero
 
-/obj/item/ammo_magazine/box_twelvegauge/buckshot/handmade
+/obj/item/ammo_magazine/box_twelvegauge/buckshot/tierzero
 	name = "packet of makeshift 12g buckshot shells"
 	desc = "Container of dubious origin intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g0_buckshot"
@@ -40,9 +40,9 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/handmade
+	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/tierzero
 
-/obj/item/ammo_magazine/box_twelvegauge/slug/simple
+/obj/item/ammo_magazine/box_twelvegauge/slug/tierone
 	name = "packet of standard 12g slug shells"
 	desc = "Container of ancient design intended for holding loose 12g slug shells."
 	icon_state = "box_12g1_slug"
@@ -52,9 +52,9 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/simple
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tierone
 
-/obj/item/ammo_magazine/box_twelvegauge/buckshot/simple
+/obj/item/ammo_magazine/box_twelvegauge/buckshot/tierone
 	name = "packet of standard 12g buckshot shells"
 	desc = "Container of ancient design intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g1_buckshot"
@@ -64,9 +64,9 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/simple
+	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/tierone
 
-/obj/item/ammo_magazine/box_twelvegauge/slug/advanced
+/obj/item/ammo_magazine/box_twelvegauge/slug/tiertwo
 	name = "packet of advanced 12g slug shells"
 	desc = "Container of modern design intended for holding loose 12g slug shells."
 	icon_state = "box_12g2_slug"
@@ -77,9 +77,9 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/advanced
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tiertwo
 
-/obj/item/ammo_magazine/box_twelvegauge/buckshot/advanced
+/obj/item/ammo_magazine/box_twelvegauge/buckshot/tiertwo
 	name = "packet of advanced 12g buckshot shells"
 	desc = "Container of modern design intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g2_buckshot"
@@ -90,4 +90,4 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/advanced
+	ammo_type = /obj/item/ammo_casing/twelvegauge/buckshot/tiertwo

--- a/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/12g/magazines.dm
@@ -24,7 +24,7 @@
 	name = "packet of makeshift 12g slug shells"
 	desc = "Container of dubious origin intended for holding loose 12g slug shells."
 	icon_state = "box_12g0_slug"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
@@ -35,7 +35,7 @@
 	name = "packet of makeshift 12g buckshot shells"
 	desc = "Container of dubious origin intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g0_buckshot"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
@@ -46,7 +46,7 @@
 	name = "packet of standard 12g slug shells"
 	desc = "Container of ancient design intended for holding loose 12g slug shells."
 	icon_state = "box_12g1_slug"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -58,7 +58,7 @@
 	name = "packet of standard 12g buckshot shells"
 	desc = "Container of ancient design intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g1_buckshot"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -70,7 +70,7 @@
 	name = "packet of advanced 12g slug shells"
 	desc = "Container of modern design intended for holding loose 12g slug shells."
 	icon_state = "box_12g2_slug"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -83,7 +83,7 @@
 	name = "packet of advanced 12g buckshot shells"
 	desc = "Container of modern design intended for holding loose 12g buckshot shells."
 	icon_state = "box_12g2_buckshot"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,

--- a/mods/persistence/modules/projectiles/ammunition/22_LR/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/22_LR/bullets.dm
@@ -12,34 +12,34 @@
 	damage = 10
 	distance_falloff = 1
 
-/obj/item/ammo_casing/twentytwolr/handmade
+/obj/item/ammo_casing/twentytwolr/tierzero
 	name = "makeshift .22LR round"
 	desc = ".22 Long Rifle round of dubious origin. Sports poor range and very poor armor penetration due to shoddy construction."
 	icon = 'mods/persistence/icons/obj/ammunition/22lr/tier0.dmi'
-	projectile_type = /obj/item/projectile/bullet/twentytwolr/handmade
+	projectile_type = /obj/item/projectile/bullet/twentytwolr/tierzero
 
-/obj/item/projectile/bullet/twentytwolr/handmade
+/obj/item/projectile/bullet/twentytwolr/tierzero
 	damage = 15
 	distance_falloff = 6
 	penetration_modifier = 1.5
 
-/obj/item/ammo_casing/twentytwolr/simple
+/obj/item/ammo_casing/twentytwolr/tierone
 	name = "standard .22LR round"
 	desc = ".22 Long Rifle round of ancient design. Sports unimpressive range and poor armor penetration due to low velocity."
 	icon = 'mods/persistence/icons/obj/ammunition/22lr/tier1.dmi'
-	projectile_type = /obj/item/projectile/bullet/twentytwolr/simple
+	projectile_type = /obj/item/projectile/bullet/twentytwolr/tierone
 
-/obj/item/projectile/bullet/twentytwolr/simple
+/obj/item/projectile/bullet/twentytwolr/tierone
 	damage = 25
 	distance_falloff = 4
 	penetration_modifier = 1.2
 
-/obj/item/ammo_casing/twentytwolr/advanced
+/obj/item/ammo_casing/twentytwolr/tiertwo
 	name = "advanced .22LR round"
-	desc = ".22 Long Rifle round of ancient design. Sports mediocre range and unimpressive armor penetration due to low velocity."
+	desc = ".22 Long Rifle round of modern design. Sports mediocre range and unimpressive armor penetration due to low velocity."
 	icon = 'mods/persistence/icons/obj/ammunition/22lr/tier2.dmi'
-	projectile_type = /obj/item/projectile/bullet/twentytwolr/advanced
+	projectile_type = /obj/item/projectile/bullet/twentytwolr/tiertwo
 
-/obj/item/projectile/bullet/twentytwolr/advanced
+/obj/item/projectile/bullet/twentytwolr/tiertwo
 	damage = 30
 	distance_falloff = 3

--- a/mods/persistence/modules/projectiles/ammunition/22_LR/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/22_LR/magazines.dm
@@ -25,7 +25,7 @@
 	name = "makeshift .22LR magazine"
 	desc = ".22LR magazine of dubious origin. Suffers from reduced capacity due to flimsy materials and shoddy craftsmanship."
 	icon_state = "22lr0"
-	origin_tech = "{'combat':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
 	ammo_type = /obj/item/ammo_casing/twentytwolr/handmade
 	max_ammo = 5
@@ -34,7 +34,7 @@
 	name = "packet of makeshift .22LR rounds"
 	desc = "Container of dubious origin intended for holding loose .22LR rounds."
 	icon_state = "box_22lr0"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
@@ -45,7 +45,7 @@
 	name = "standard .22LR magazine"
 	desc = ".22LR magazine of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "22lr1"
-	origin_tech = "{'combat':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
@@ -57,7 +57,7 @@
 	name = "packet of standard .22LR rounds"
 	desc = "Container of ancient design intended for holding loose .22LR rounds."
 	icon_state = "box_22lr1"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -69,7 +69,7 @@
 	name = "advanced .22LR magazine"
 	desc = ".22LR magazine of modern design. Good capacity, and can be used well with both handguns and submachine guns alike."
 	icon_state = "22lr2"
-	origin_tech = "{'combat':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
@@ -82,7 +82,7 @@
 	name = "packet of advanced .22LR rounds"
 	desc = "Container of modern design intended for holding loose .22LR rounds."
 	icon_state = "box_22lr2"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,

--- a/mods/persistence/modules/projectiles/ammunition/22_LR/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/22_LR/magazines.dm
@@ -21,16 +21,16 @@
 	ammo_type = /obj/item/ammo_casing/twentytwolr
 	max_ammo = 30
 
-/obj/item/ammo_magazine/twentytwolr/handmade
+/obj/item/ammo_magazine/twentytwolr/tierzero
 	name = "makeshift .22LR magazine"
 	desc = ".22LR magazine of dubious origin. Suffers from reduced capacity due to flimsy materials and shoddy craftsmanship."
 	icon_state = "22lr0"
 	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
-	ammo_type = /obj/item/ammo_casing/twentytwolr/handmade
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tierzero
 	max_ammo = 5
 
-/obj/item/ammo_magazine/box_twentytwolr/handmade
+/obj/item/ammo_magazine/box_twentytwolr/tierzero
 	name = "packet of makeshift .22LR rounds"
 	desc = "Container of dubious origin intended for holding loose .22LR rounds."
 	icon_state = "box_22lr0"
@@ -39,9 +39,9 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twentytwolr/handmade
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tierzero
 
-/obj/item/ammo_magazine/twentytwolr/simple
+/obj/item/ammo_magazine/twentytwolr/tierone
 	name = "standard .22LR magazine"
 	desc = ".22LR magazine of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "22lr1"
@@ -50,10 +50,10 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/twentytwolr/simple
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tierone
 	max_ammo = 12
 
-/obj/item/ammo_magazine/box_twentytwolr/simple
+/obj/item/ammo_magazine/box_twentytwolr/tierone
 	name = "packet of standard .22LR rounds"
 	desc = "Container of ancient design intended for holding loose .22LR rounds."
 	icon_state = "box_22lr1"
@@ -63,9 +63,9 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twentytwolr/simple
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tierone
 
-/obj/item/ammo_magazine/twentytwolr/advanced
+/obj/item/ammo_magazine/twentytwolr/tiertwo
 	name = "advanced .22LR magazine"
 	desc = ".22LR magazine of modern design. Good capacity, and can be used well with both handguns and submachine guns alike."
 	icon_state = "22lr2"
@@ -75,10 +75,10 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/twentytwolr/advanced
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tiertwo
 	max_ammo = 20
 
-/obj/item/ammo_magazine/box_twentytwolr/advanced
+/obj/item/ammo_magazine/box_twentytwolr/tiertwo
 	name = "packet of advanced .22LR rounds"
 	desc = "Container of modern design intended for holding loose .22LR rounds."
 	icon_state = "box_22lr2"
@@ -89,4 +89,4 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/twentytwolr/advanced
+	ammo_type = /obj/item/ammo_casing/twentytwolr/tiertwo

--- a/mods/persistence/modules/projectiles/ammunition/357/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/357/bullets.dm
@@ -16,7 +16,7 @@
 	name = "makeshift .357 round"
 	desc = ".357 round of dubious origin. Sports poor range and poor armor penetration due to shoddy construction."
 	icon = 'mods/persistence/icons/obj/ammunition/357/tier0.dmi'
-	projectile_type = /obj/item/projectile/bullet/threefiftyseven/handmade
+	projectile_type = /obj/item/projectile/bullet/threefiftyseven/tierzero
 
 /obj/item/projectile/bullet/threefiftyseven/tierzero
 	damage = 40

--- a/mods/persistence/modules/projectiles/ammunition/357/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/357/bullets.dm
@@ -12,34 +12,34 @@
 	damage = 30
 	distance_falloff = 1
 
-/obj/item/ammo_casing/threefiftyseven/handmade
+/obj/item/ammo_casing/threefiftyseven/tierzero
 	name = "makeshift .357 round"
 	desc = ".357 round of dubious origin. Sports poor range and poor armor penetration due to shoddy construction."
 	icon = 'mods/persistence/icons/obj/ammunition/357/tier0.dmi'
 	projectile_type = /obj/item/projectile/bullet/threefiftyseven/handmade
 
-/obj/item/projectile/bullet/threefiftyseven/handmade
+/obj/item/projectile/bullet/threefiftyseven/tierzero
 	damage = 40
 	distance_falloff = 6
 
-/obj/item/ammo_casing/threefiftyseven/simple
+/obj/item/ammo_casing/threefiftyseven/tierone
 	name = "standard .357 round"
 	desc = ".357 round of ancient design. Sports mediocre range due to unimpressive velocity."
 	icon = 'mods/persistence/icons/obj/ammunition/357/tier1.dmi'
-	projectile_type = /obj/item/projectile/bullet/threefiftyseven/simple
+	projectile_type = /obj/item/projectile/bullet/threefiftyseven/tierone
 
-/obj/item/projectile/bullet/threefiftyseven/simple
+/obj/item/projectile/bullet/threefiftyseven/tierone
 	damage = 50
 	distance_falloff = 4
 	penetration_modifier = 0.9
 
-/obj/item/ammo_casing/threefiftyseven/advanced
+/obj/item/ammo_casing/threefiftyseven/tiertwo
 	name = "advanced .357 round"
 	desc = ".357 round of modern design. Sports middling range and acceptable armor penetration due to modern construction techniques."
 	icon = 'mods/persistence/icons/obj/ammunition/357/tier2.dmi'
-	projectile_type = /obj/item/projectile/bullet/threefiftyseven/advanced
+	projectile_type = /obj/item/projectile/bullet/threefiftyseven/tiertwo
 
-/obj/item/projectile/bullet/threefiftyseven/advanced
+/obj/item/projectile/bullet/threefiftyseven/tiertwo
 	damage = 60
 	distance_falloff = 3
 	penetration_modifier = 0.8

--- a/mods/persistence/modules/projectiles/ammunition/357/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/357/magazines.dm
@@ -21,31 +21,31 @@
 	ammo_type = /obj/item/ammo_casing/threefiftyseven
 	max_ammo = 12
 
-/obj/item/ammo_magazine/threefiftyseven/handmade
+/obj/item/ammo_magazine/threefiftyseven/tierzero
 	name = "makeshift .357 speedloader"
 	desc = ".357 speedloader of dubious origin. Suffers from reduced capacity due to flimsy materials and shoddy craftsmanship."
 	icon_state = "3570"
-	origin_tech = "{'combat':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/handmade
 	max_ammo = 3
 
-/obj/item/ammo_magazine/box_threefiftyseven/handmade
+/obj/item/ammo_magazine/box_threefiftyseven/tierzero
 	name = "packet of makeshift .357 rounds"
 	desc = "Container of dubious origin intended for holding loose .357 rounds."
 	icon_state = "box_3570"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/handmade
 
-/obj/item/ammo_magazine/threefiftyseven/simple
+/obj/item/ammo_magazine/threefiftyseven/tierone
 	name = "standard .357 speedloader"
 	desc = ".357 speedloader of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "3571"
-	origin_tech = "{'combat':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
@@ -53,11 +53,11 @@
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
 	max_ammo = 4
 
-/obj/item/ammo_magazine/box_threefiftyseven/simple
+/obj/item/ammo_magazine/box_threefiftyseven/tierone
 	name = "packet of standard .357 rounds"
 	desc = "Container of ancient design intended for holding loose .357 rounds."
 	icon_state = "box_3571"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -65,11 +65,11 @@
 	)
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
 
-/obj/item/ammo_magazine/threefiftyseven/advanced
+/obj/item/ammo_magazine/threefiftyseven/tiertwo
 	name = "advanced .357 speedloader"
 	desc = ".357 speedloader of modern design. Improved capacity over earlier designs."
 	icon_state = "3572"
-	origin_tech = "{'combat':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -78,11 +78,11 @@
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/advanced
 	max_ammo = 5
 
-/obj/item/ammo_magazine/box_threefiftyseven/advanced
+/obj/item/ammo_magazine/box_threefiftyseven/tiertwo
 	name = "packet of advanced .357 rounds"
 	desc = "Container of modern design intended for holding loose .357 rounds."
 	icon_state = "box_3572"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,

--- a/mods/persistence/modules/projectiles/ammunition/357/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/357/magazines.dm
@@ -27,7 +27,7 @@
 	icon_state = "3570"
 	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/handmade
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tierzero
 	max_ammo = 3
 
 /obj/item/ammo_magazine/box_threefiftyseven/tierzero
@@ -39,7 +39,7 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/handmade
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tierzero
 
 /obj/item/ammo_magazine/threefiftyseven/tierone
 	name = "standard .357 speedloader"
@@ -50,7 +50,7 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tierone
 	max_ammo = 4
 
 /obj/item/ammo_magazine/box_threefiftyseven/tierone
@@ -63,7 +63,7 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tierone
 
 /obj/item/ammo_magazine/threefiftyseven/tiertwo
 	name = "advanced .357 speedloader"
@@ -75,7 +75,7 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/advanced
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tiertwo
 	max_ammo = 5
 
 /obj/item/ammo_magazine/box_threefiftyseven/tiertwo
@@ -89,4 +89,4 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/advanced
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tiertwo

--- a/mods/persistence/modules/projectiles/ammunition/45/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/45/bullets.dm
@@ -12,34 +12,34 @@
 	damage = 20
 	distance_falloff = 1
 
-/obj/item/ammo_casing/fortyfive/handmade
+/obj/item/ammo_casing/fortyfive/tierzero
 	name = "makeshift .45 round"
 	desc = ".45 round of dubious origin. Sports poor range and poor armor penetration due to shoddy construction."
 	icon = 'mods/persistence/icons/obj/ammunition/45/tier0.dmi'
-	projectile_type = /obj/item/projectile/bullet/fortyfive/handmade
+	projectile_type = /obj/item/projectile/bullet/fortyfive/tierzero
 
-/obj/item/projectile/bullet/fortyfive/handmade
+/obj/item/projectile/bullet/fortyfive/tierzero
 	damage = 30
 	distance_falloff = 5
 	penetration_modifier = 1.2
 
-/obj/item/ammo_casing/fortyfive/simple
+/obj/item/ammo_casing/fortyfive/tierone
 	name = "standard .45 round"
 	desc = ".45 round of ancient design. Sports mediocre range due to unimpressive velocity."
 	icon = 'mods/persistence/icons/obj/ammunition/45/tier1.dmi'
-	projectile_type = /obj/item/projectile/bullet/fortyfive/simple
+	projectile_type = /obj/item/projectile/bullet/fortyfive/tierone
 
-/obj/item/projectile/bullet/fortyfive/simple
+/obj/item/projectile/bullet/fortyfive/tierone
 	damage = 40
 	distance_falloff = 3
 
-/obj/item/ammo_casing/fortyfive/advanced
+/obj/item/ammo_casing/fortyfive/tiertwo
 	name = "advanced .45 round"
 	desc = ".45 round of modern design. Sports acceptable range and mediocre armor penetration due to modern construction techniques."
 	icon = 'mods/persistence/icons/obj/ammunition/45/tier2.dmi'
-	projectile_type = /obj/item/projectile/bullet/fortyfive/advanced
+	projectile_type = /obj/item/projectile/bullet/fortyfive/tiertwo
 
-/obj/item/projectile/bullet/fortyfive/advanced
+/obj/item/projectile/bullet/fortyfive/tiertwo
 	damage = 50
 	distance_falloff = 2
 	penetration_modifier = 0.9

--- a/mods/persistence/modules/projectiles/ammunition/45/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/45/magazines.dm
@@ -21,72 +21,72 @@
 	ammo_type = /obj/item/ammo_casing/fortyfive
 	max_ammo = 20
 
-/obj/item/ammo_magazine/fortyfive/handmade
+/obj/item/ammo_magazine/fortyfive/tierzero
 	name = "makeshift .45 magazine"
 	desc = ".45 magazine of dubious origin. Suffers from reduced capacity due to flimsy materials and shoddy craftsmanship."
 	icon_state = "450"
-	origin_tech = "{'combat':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
-	ammo_type = /obj/item/ammo_casing/fortyfive/handmade
+	ammo_type = /obj/item/ammo_casing/fortyfive/tierzero
 	max_ammo = 3
 
-/obj/item/ammo_magazine/box_fortyfive/handmade
+/obj/item/ammo_magazine/box_fortyfive/tierzero
 	name = "packet of makeshift .45 rounds"
 	desc = "Container of dubious origin intended for holding loose .45 rounds."
 	icon_state = "box_450"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fortyfive/handmade
+	ammo_type = /obj/item/ammo_casing/fortyfive/tierzero
 
-/obj/item/ammo_magazine/fortyfive/simple
+/obj/item/ammo_magazine/fortyfive/tierone
 	name = "standard .45 magazine"
 	desc = ".45 magazine of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "451"
-	origin_tech = "{'combat':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/fortyfive/simple
+	ammo_type = /obj/item/ammo_casing/fortyfive/tierone
 	max_ammo = 7
 
-/obj/item/ammo_magazine/box_fortyfive/simple
+/obj/item/ammo_magazine/box_fortyfive/tierone
 	name = "packet of standard .45 rounds"
 	desc = "Container of ancient design intended for holding loose .45 rounds."
 	icon_state = "box_451"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fortyfive/simple
+	ammo_type = /obj/item/ammo_casing/fortyfive/tierone
 
-/obj/item/ammo_magazine/fortyfive/advanced
+/obj/item/ammo_magazine/fortyfive/tiertwo
 	name = "standard .45 magazine"
 	desc = ".45 magazine of modern design. Improved capacity compared over older versions."
 	icon_state = "452"
-	origin_tech = "{'combat':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/fortyfive/advanced
+	ammo_type = /obj/item/ammo_casing/fortyfive/tiertwo
 	max_ammo = 12
 
-/obj/item/ammo_magazine/box_fortyfive/advanced
+/obj/item/ammo_magazine/box_fortyfive/tiertwo
 	name = "packet of advanced .45 rounds"
 	desc = "Container of modern design intended for holding loose .45 rounds."
 	icon_state = "box_452"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fortyfive/advanced
+	ammo_type = /obj/item/ammo_casing/fortyfive/tiertwo

--- a/mods/persistence/modules/projectiles/ammunition/5.56/bullets.dm
+++ b/mods/persistence/modules/projectiles/ammunition/5.56/bullets.dm
@@ -12,35 +12,35 @@
 	damage = 25
 	distance_falloff = 1
 
-/obj/item/ammo_casing/fivefiftysix/handmade
+/obj/item/ammo_casing/fivefiftysix/tierzero
 	name = "makeshift 5.56x45mm round"
 	desc = "5.56x45mm round of dubious origin. Sports poor range and poor armor penetration due to shoddy construction."
 	icon = 'mods/persistence/icons/obj/ammunition/5.56/tier0.dmi'
-	projectile_type = /obj/item/projectile/bullet/fivefiftysix/handmade
+	projectile_type = /obj/item/projectile/bullet/fivefiftysix/tierzero
 
-/obj/item/projectile/bullet/fivefiftysix/handmade
+/obj/item/projectile/bullet/fivefiftysix/tierzero
 	damage = 35
 	distance_falloff = 4
 	penetration_modifier = 1
 
-/obj/item/ammo_casing/fivefiftysix/simple
+/obj/item/ammo_casing/fivefiftysix/tierone
 	name = "standard 5.56x45mm round"
 	desc = "5.56x45mm round of ancient design. Sports good armor penetration capabilities, but most firearms which use it are bulky."
 	icon = 'mods/persistence/icons/obj/ammunition/5.56/tier1.dmi'
-	projectile_type = /obj/item/projectile/bullet/fivefiftysix/simple
+	projectile_type = /obj/item/projectile/bullet/fivefiftysix/tierone
 
-/obj/item/projectile/bullet/fivefiftysix/simple
+/obj/item/projectile/bullet/fivefiftysix/tierone
 	damage = 45
 	distance_falloff = 2
 	penetration_modifier = 0.8
 
-/obj/item/ammo_casing/fivefiftysix/advanced
+/obj/item/ammo_casing/fivefiftysix/tiertwo
 	name = "advanced 5.56x45mm round"
 	desc = "5.56x45mm round of modern design. Sports great armor penetration capabilities, but most firearms which use it are bulky."
 	icon = 'mods/persistence/icons/obj/ammunition/5.56/tier2.dmi'
-	projectile_type = /obj/item/projectile/bullet/fivefiftysix/advanced
+	projectile_type = /obj/item/projectile/bullet/fivefiftysix/tiertwo
 
-/obj/item/projectile/bullet/fivefiftysix/advanced
+/obj/item/projectile/bullet/fivefiftysix/tiertwo
 	damage = 55
 	distance_falloff = 1
 	penetration_modifier = 0.7

--- a/mods/persistence/modules/projectiles/ammunition/5.56/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/5.56/magazines.dm
@@ -21,16 +21,16 @@
 	ammo_type = /obj/item/ammo_casing/fivefiftysix
 	max_ammo = 50
 
-/obj/item/ammo_magazine/fivefiftysix/handmade
+/obj/item/ammo_magazine/fivefiftysix/tierzero
 	name = "makeshift 5.56x45mm magazine"
 	desc = "5.56x45mm magazine of dubious origin. Suffers from reduced capacity due to flimsy materials and shoddy craftsmanship."
 	icon_state = "5560"
-	origin_tech = "{'combat':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/organic/plastic
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/handmade
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierzero
 	max_ammo = 12
 
-/obj/item/ammo_magazine/box_fivefiftysix/handmade
+/obj/item/ammo_magazine/box_fivefiftysix/tierzero
 	name = "packet of makeshift 5.56x45mm rounds"
 	desc = "Container of dubious origin intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5560"
@@ -39,9 +39,9 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/handmade
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierzero
 
-/obj/item/ammo_magazine/fivefiftysix/simple
+/obj/item/ammo_magazine/fivefiftysix/tierone
 	name = "standard 5.56x45mm magazine"
 	desc = "5.56x45mm magazine of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "5561"
@@ -50,10 +50,10 @@
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/simple
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierone
 	max_ammo = 20
 
-/obj/item/ammo_magazine/box_fivefiftysix/simple
+/obj/item/ammo_magazine/box_fivefiftysix/tierone
 	name = "packet of standard 5.56x45mm rounds"
 	desc = "Container of ancient design intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5561"
@@ -63,9 +63,9 @@
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/simple
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierone
 
-/obj/item/ammo_magazine/fivefiftysix/advanced
+/obj/item/ammo_magazine/fivefiftysix/tiertwo
 	name = "advanced 5.56x45mm magazine"
 	desc = "5.56x45mm magazine of modern design. Good capacity compared to earlier models."
 	icon_state = "5562"
@@ -75,10 +75,10 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT
 	)
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/simple
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tiertwo
 	max_ammo = 30
 
-/obj/item/ammo_magazine/box_fivefiftysix/advanced
+/obj/item/ammo_magazine/box_fivefiftysix/tiertwo
 	name = "packet of advanced 5.56x45mm rounds"
 	desc = "Container of modern design intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5562"
@@ -89,4 +89,4 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/organic/cardboard = MATTER_AMOUNT_TRACE
 	)
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/simple
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tiertwo

--- a/mods/persistence/modules/projectiles/ammunition/5.56/magazines.dm
+++ b/mods/persistence/modules/projectiles/ammunition/5.56/magazines.dm
@@ -34,7 +34,7 @@
 	name = "packet of makeshift 5.56x45mm rounds"
 	desc = "Container of dubious origin intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5560"
-	origin_tech = "{'combat':1,'materials':1}"
+	origin_tech = "{'combat':5,'materials':5}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
@@ -45,7 +45,7 @@
 	name = "standard 5.56x45mm magazine"
 	desc = "5.56x45mm magazine of ancient design. Servicable capacity, but outpaced by more modern designs."
 	icon_state = "5561"
-	origin_tech = "{'combat':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
@@ -57,7 +57,7 @@
 	name = "packet of standard 5.56x45mm rounds"
 	desc = "Container of ancient design intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5561"
-	origin_tech = "{'combat':2,'materials':2}"
+	origin_tech = "{'combat':8,'materials':8}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,
@@ -69,7 +69,7 @@
 	name = "advanced 5.56x45mm magazine"
 	desc = "5.56x45mm magazine of modern design. Good capacity compared to earlier models."
 	icon_state = "5562"
-	origin_tech = "{'combat':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
@@ -82,7 +82,7 @@
 	name = "packet of advanced 5.56x45mm rounds"
 	desc = "Container of modern design intended for holding loose 5.56x45mm rounds."
 	icon_state = "box_5562"
-	origin_tech = "{'combat':3,'materials':3}"
+	origin_tech = "{'combat':12,'materials':12}"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic   = MATTER_AMOUNT_REINFORCEMENT,

--- a/mods/persistence/modules/projectiles/guns/energy/tier0/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier0/lasrifle.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser/rifle/handmade
-	name = "Laser 'Tagger' EG"
+	name = "Laser 'Tagger' T0-EG"
 	desc = "Laser rifle of dubious origin. Shoddy craftsmanship results in low charge capacity and weak output. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier0/lasrifle.dmi'
 	slot_flags = SLOT_LOWER_BODY|SLOT_BACK
@@ -8,7 +8,7 @@
 	one_hand_penalty = 3
 	max_shots = 3
 	fire_delay = 15
-	origin_tech = "{'combat':2,'magnets':1,'engineering':1,'materials':2}"
+	origin_tech = "{'combat':5,'engineering':5,'materials':2,'magnets':2}"
 	projectile_type = /obj/item/projectile/beam/smalllaser
 	material = /decl/material/solid/metal/steel
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/energy/tier0/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier0/lasrifle.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/laser/rifle/handmade
+/obj/item/gun/energy/laser/rifle/tierzero
 	name = "Laser 'Tagger' T0-EG"
 	desc = "Laser rifle of dubious origin. Shoddy craftsmanship results in low charge capacity and weak output. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier0/lasrifle.dmi'

--- a/mods/persistence/modules/projectiles/guns/energy/tier1/laspistol.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier1/laspistol.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/laser/pistol/simple
+/obj/item/gun/energy/laser/pistol/tierone
 	name = "Laser 'Settler' T1-EG"
 	desc = "Laser pistol used by modern spacers. Compact, but suffers from low charge capacity because of this. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier1/laspistol.dmi'

--- a/mods/persistence/modules/projectiles/guns/energy/tier1/laspistol.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier1/laspistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser/pistol/simple
-	name = "Laser 'Settler' EG"
+	name = "Laser 'Settler' T1-EG"
 	desc = "Laser pistol used by modern spacers. Compact, but suffers from low charge capacity because of this. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier1/laspistol.dmi'
 	slot_flags = SLOT_LOWER_BODY
@@ -8,7 +8,7 @@
 	max_shots = 6
 	fire_delay = 5
 	force = 3 // made of light-ish plastics rather than wood and metal
-	origin_tech = "{'combat':3,'magnets':2,'engineering':2,'materials':3}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4,'magnets':4}"
 	projectile_type = /obj/item/projectile/beam/smalllaser
 	material = /decl/material/solid/metal/aluminium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/energy/tier1/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier1/lasrifle.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser/rifle/simple
-	name = "Laser 'Marine' EG"
+	name = "Laser 'Marine' T1-EG"
 	desc = "Laser rifle used by modern spacers. Powerful, but bulky and suffers from low charge capacity. Fires Beta-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier1/lasrifle.dmi'
 	slot_flags = SLOT_BACK
@@ -8,7 +8,7 @@
 	max_shots = 5
 	fire_delay = 12
 	force = 10
-	origin_tech = "{'combat':3,'magnets':2,'engineering':2,'materials':3}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4,'magnets':4}"
 	projectile_type = /obj/item/projectile/beam/midlaser
 	material = /decl/material/solid/metal/aluminium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/energy/tier1/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier1/lasrifle.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/laser/rifle/simple
+/obj/item/gun/energy/laser/rifle/tierone
 	name = "Laser 'Marine' T1-EG"
 	desc = "Laser rifle used by modern spacers. Powerful, but bulky and suffers from low charge capacity. Fires Beta-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier1/lasrifle.dmi'

--- a/mods/persistence/modules/projectiles/guns/energy/tier2/laspistol.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier2/laspistol.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/laser/pistol/advanced
+/obj/item/gun/energy/laser/pistol/tiertwo
 	name = "Laser 'Martin' T2-EG"
 	desc = "Laser pistol used by modern high-tech military groups. Compact, quick-firing, and boasts acceptable charge capacity due to advanced construction. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier2/laspistol.dmi'

--- a/mods/persistence/modules/projectiles/guns/energy/tier2/laspistol.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier2/laspistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser/pistol/advanced
-	name = "Laser 'Martin' EG"
+	name = "Laser 'Martin' T2-EG"
 	desc = "Laser pistol used by modern high-tech military groups. Compact, quick-firing, and boasts acceptable charge capacity due to advanced construction. Fires Alpha-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier2/laspistol.dmi'
 	slot_flags = SLOT_LOWER_BODY
@@ -8,7 +8,7 @@
 	max_shots = 12
 	fire_delay = 3
 	force = 3
-	origin_tech = "{'combat':4,'magnets':3,'engineering':4,'materials':3}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6,'magnets':6}"
 	projectile_type = /obj/item/projectile/beam/smalllaser
 	material = /decl/material/solid/metal/titanium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/energy/tier2/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier2/lasrifle.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/energy/laser/rifle/advanced
+/obj/item/gun/energy/laser/rifle/tiertwo
 	name = "Laser 'Frontrunner' T2-EG"
 	desc = "Laser rifle used by modern high-tech military groups. Powerful compared to previous models of laser weapons, and boasts decent charge capacity. Fires Beta-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier2/lasrifle.dmi'

--- a/mods/persistence/modules/projectiles/guns/energy/tier2/lasrifle.dm
+++ b/mods/persistence/modules/projectiles/guns/energy/tier2/lasrifle.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/laser/rifle/advanced
-	name = "Laser 'Frontrunner' EG"
+	name = "Laser 'Frontrunner' T2-EG"
 	desc = "Laser rifle used by modern high-tech military groups. Powerful compared to previous models of laser weapons, and boasts decent charge capacity. Fires Beta-type laser beams."
 	icon = 'mods/persistence/icons/obj/guns/tier2/lasrifle.dmi'
 	slot_flags = SLOT_BACK
@@ -8,7 +8,7 @@
 	max_shots = 8
 	fire_delay = 12
 	force = 10
-	origin_tech = "{'combat':4,'magnets':4,'engineering':3,'materials':3}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6,'magnets':6}"
 	projectile_type = /obj/item/projectile/beam/midlaser
 	material = /decl/material/solid/metal/titanium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/bolt_action/handmade
-	name = "5.56x45mm 'Minuteman' BA"
+	name = "5.56x45mm 'Minuteman' T0-BA"
 	desc = "Bolt-action rifle of dubious origin. Shoddy craftsmanship results in extremely low ammo capacity. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier0/boltaction.dmi'
 	force = 10

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
@@ -4,7 +4,7 @@
 	icon = 'mods/persistence/icons/obj/guns/tier0/boltaction.dmi'
 	force = 10
 	slot_flags = SLOT_BACK
-	origin_tech = "{'combat':2,'engineering':1,'materials':1}"
+	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
 	caliber = CALIBER_556
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
@@ -4,7 +4,7 @@
 	icon = 'mods/persistence/icons/obj/guns/tier0/boltaction.dmi'
 	force = 10
 	slot_flags = SLOT_BACK
-	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
+	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
 	caliber = CALIBER_556
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/bolt_action/handmade
+/obj/item/gun/projectile/bolt_action/tierzero
 	name = "5.56x45mm 'Minuteman' T0-BA"
 	desc = "Bolt-action rifle of dubious origin. Shoddy craftsmanship results in extremely low ammo capacity. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier0/boltaction.dmi'
@@ -18,5 +18,5 @@
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT
 	)
 
-/obj/item/gun/projectile/bolt_action/handmade/empty
+/obj/item/gun/projectile/bolt_action/tierzero/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/boltaction.dm
@@ -9,7 +9,7 @@
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING
 	max_shells = 1
-	ammo_type = /obj/item/ammo_casing/fivefiftysix/handmade
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierzero
 	one_hand_penalty = 20
 	fire_delay = 20
 	accuracy = -1

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
@@ -6,7 +6,7 @@
 	force = 5
 	accuracy = 0
 	one_hand_penalty = 2
-	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
+	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
@@ -1,12 +1,12 @@
 /obj/item/gun/projectile/pistol/handmade
-	name = ".22LR 'Zip' HG"
+	name = ".22LR 'Zip' T0-HG"
 	desc = "Pistol of dubious origin. Struggles against armored targets, but carries the benefits of magazines over hand-loading. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier0/pistol.dmi'
 	fire_delay = 8
 	force = 5
 	accuracy = 0
 	one_hand_penalty = 2
-	origin_tech = "{'combat':5,'engineering':4,'materials':2}" // 2 design requirements
+	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/handmade
+/obj/item/gun/projectile/pistol/tierzero
 	name = ".22LR 'Zip' T0-HG"
 	desc = "Pistol of dubious origin. Struggles against armored targets, but carries the benefits of magazines over hand-loading. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier0/pistol.dmi'
@@ -17,5 +17,5 @@
 		/decl/material/solid/organic/wood = MATTER_AMOUNT_REINFORCEMENT
 	)
 
-/obj/item/gun/projectile/pistol/handmade/empty
+/obj/item/gun/projectile/pistol/tierzero/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
@@ -6,7 +6,7 @@
 	force = 5
 	accuracy = 0
 	one_hand_penalty = 2
-	origin_tech = "{'combat':2,'engineering':1,'materials':1}"
+	origin_tech = "{'combat':5,'engineering':4,'materials':2}" // 2 design requirements
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/pistol.dm
@@ -10,7 +10,7 @@
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL
-	magazine_type = /obj/item/ammo_magazine/twentytwolr/handmade
+	magazine_type = /obj/item/ammo_magazine/twentytwolr/tierzero
 	allowed_magazines = /obj/item/ammo_magazine/twentytwolr
 	material = /decl/material/solid/metal/steel
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/revolver/handmade
+/obj/item/gun/projectile/revolver/tierzero
 	name = ".45 'Underdog' T0-RV"
 	desc = "Revolver of dubious origin. Shoddy craftsmanship results in low ammo capacity and high recoil. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier0/revolver.dmi'
@@ -16,5 +16,5 @@
 		/decl/material/solid/organic/wood = MATTER_AMOUNT_REINFORCEMENT
 	)
 
-/obj/item/gun/projectile/revolver/handmade/empty
+/obj/item/gun/projectile/revolver/tierzero/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/handmade
-	name = ".45 'Underdog' RV"
+	name = ".45 'Underdog' T0-RV"
 	desc = "Revolver of dubious origin. Shoddy craftsmanship results in low ammo capacity and high recoil. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier0/revolver.dmi'
 	origin_tech = "{'combat':2,'engineering':1,'materials':1}"

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
@@ -2,7 +2,7 @@
 	name = ".45 'Underdog' T0-RV"
 	desc = "Revolver of dubious origin. Shoddy craftsmanship results in low ammo capacity and high recoil. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier0/revolver.dmi'
-	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
+	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
 	caliber = CALIBER_45
 	ammo_type = /obj/item/ammo_casing/fortyfive/handmade
 	max_shells = 3

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
@@ -2,7 +2,7 @@
 	name = ".45 'Underdog' T0-RV"
 	desc = "Revolver of dubious origin. Shoddy craftsmanship results in low ammo capacity and high recoil. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier0/revolver.dmi'
-	origin_tech = "{'combat':2,'engineering':1,'materials':1}"
+	origin_tech = "{'combat':5,'engineering':4,'materials':2}"
 	caliber = CALIBER_45
 	ammo_type = /obj/item/ammo_casing/fortyfive/handmade
 	max_shells = 3

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/revolver.dm
@@ -4,7 +4,7 @@
 	icon = 'mods/persistence/icons/obj/guns/tier0/revolver.dmi'
 	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
 	caliber = CALIBER_45
-	ammo_type = /obj/item/ammo_casing/fortyfive/handmade
+	ammo_type = /obj/item/ammo_casing/fortyfive/tierzero
 	max_shells = 3
 	w_class = ITEM_SIZE_NORMAL
 	fire_delay = 12

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/shotgun/handmade
+/obj/item/gun/projectile/shotgun/tierzero
 	name = "12g 'Slider' T0-SG"
 	desc = "Break-action shotgun of dubious origin. Shoddy craftsmanship results in extremely low ammo capacity and high recoil. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier0/shotgun.dmi'
@@ -19,5 +19,5 @@
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT
 	)
 
-/obj/item/gun/projectile/shotgun/handmade/empty
+/obj/item/gun/projectile/shotgun/tierzero/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/handmade
-	name = "12g 'Slider' SG"
+	name = "12g 'Slider' T0-SG"
 	desc = "Break-action shotgun of dubious origin. Shoddy craftsmanship results in extremely low ammo capacity and high recoil. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier0/shotgun.dmi'
 	load_method = SINGLE_CASING
@@ -9,7 +9,7 @@
 	force = 5 // lacks a butt for effective rifle-whipping
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
-	origin_tech = "{'combat':2,'engineering':1,'materials':1}"
+	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
 	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/handmade
 	screen_shake = 2
 	accuracy = -1

--- a/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier0/shotgun.dm
@@ -10,7 +10,7 @@
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
 	origin_tech = "{'combat':5,'engineering':5,'materials':2}"
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/handmade
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tierzero
 	screen_shake = 2
 	accuracy = -1
 	one_hand_penalty = 10

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
@@ -1,10 +1,10 @@
 /obj/item/gun/projectile/bolt_action/simple
-	name = "5.56x45mm 'Mosin' BA"
+	name = "5.56x45mm 'Mosin' T1-BA"
 	desc = "Bolt-action rifle of ancient design. Reliable, but slow-firing. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier1/boltaction.dmi'
 	force = 10
 	slot_flags = SLOT_BACK
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	caliber = CALIBER_556
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/bolt_action/simple
+/obj/item/gun/projectile/bolt_action/tierone
 	name = "5.56x45mm 'Mosin' T1-BA"
 	desc = "Bolt-action rifle of ancient design. Reliable, but slow-firing. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier1/boltaction.dmi'
@@ -20,5 +20,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/bolt_action/simple/empty
+/obj/item/gun/projectile/bolt_action/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/boltaction.dm
@@ -10,7 +10,7 @@
 	load_method = SINGLE_CASING
 	max_shells = 5
 	w_class = ITEM_SIZE_HUGE
-	ammo_type = /obj/item/ammo_casing/fivefiftysix
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tierone
 	one_hand_penalty = 10
 	fire_delay = 12
 	accuracy = 0

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/simple
+/obj/item/gun/projectile/pistol/tierone
 	name = ".45 'Colt' T1-HG"
 	desc = "Pistol of ancient design. Reliable, but struggles against armored targets. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol.dmi'
@@ -18,5 +18,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/pistol/simple/empty
+/obj/item/gun/projectile/pistol/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/pistol/simple
-	name = ".45 'Colt' HG"
+	name = ".45 'Colt' T1-HG"
 	desc = "Pistol of ancient design. Reliable, but struggles against armored targets. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol.dmi'
 	caliber = CALIBER_45
@@ -7,7 +7,7 @@
 	force = 5
 	accuracy = 1
 	one_hand_penalty = 1
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	magazine_type = /obj/item/ammo_magazine/fortyfive/simple

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol.dm
@@ -10,7 +10,7 @@
 	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL
-	magazine_type = /obj/item/ammo_magazine/fortyfive/simple
+	magazine_type = /obj/item/ammo_magazine/fortyfive/tierone
 	allowed_magazines = /obj/item/ammo_magazine/fortyfive
 	material = /decl/material/solid/metal/steel
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_gold.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_gold.dm
@@ -1,8 +1,8 @@
 /obj/item/gun/projectile/pistol/simple/golden
-	name = ".45 'Colt-M' HG"
+	name = ".45 'Colt-M' T1-HG"
 	desc = "Luxurious pistol of ancient design. Reliable and fabulous, but struggles against armored targets. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol_gold.dmi'
-	origin_tech = "{'combat':3,'engineering':2,'materials':5}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':25}" // really high design requirements to support 'luxury' status - 5 design stipulations
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/wood = MATTER_AMOUNT_REINFORCEMENT,

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_gold.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_gold.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/simple/golden
+/obj/item/gun/projectile/pistol/tierone/golden
 	name = ".45 'Colt-M' T1-HG"
 	desc = "Luxurious pistol of ancient design. Reliable and fabulous, but struggles against armored targets. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol_gold.dmi'
@@ -10,5 +10,5 @@
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_REINFORCEMENT
 	)
 
-/obj/item/gun/projectile/pistol/simple/golden/empty
+/obj/item/gun/projectile/pistol/tierone/golden/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/pistol_pocket/simple
+/obj/item/gun/projectile/pistol/pistol_pocket/tierone
 	name = ".22LR 'Rimfire' T1-HG"
 	desc = "Pistol of ancient design. Small enough to store in pockets, but struggles in combat due to weak caliber. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol_pocket.dmi'
@@ -18,5 +18,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/pistol/pistol_pocket/simple/empty
+/obj/item/gun/projectile/pistol/pistol_pocket/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
@@ -1,12 +1,12 @@
 /obj/item/gun/projectile/pistol/pistol_pocket/simple
-	name = ".22LR 'Rimfire' HG"
+	name = ".22LR 'Rimfire' T1-HG"
 	desc = "Pistol of ancient design. Small enough to store in pockets, but struggles in combat due to weak caliber. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier1/pistol_pocket.dmi'
 	fire_delay = 3
 	force = 5
 	accuracy = 1
 	one_hand_penalty = 0
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_SMALL

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/pistol_pocket.dm
@@ -10,7 +10,7 @@
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_SMALL
-	magazine_type = /obj/item/ammo_magazine/twentytwolr/simple
+	magazine_type = /obj/item/ammo_magazine/twentytwolr/tierone
 	allowed_magazines = /obj/item/ammo_magazine/twentytwolr
 	material = /decl/material/solid/metal/steel
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
@@ -1,8 +1,8 @@
 /obj/item/gun/projectile/revolver/simple
-	name = ".357 'Chief' RV"
+	name = ".357 'Chief' T1-RV"
 	desc = "Revolver of ancient design. Uses high-power rounds, but struggles with a low ammunition capacity and poor armor penetration. Chambered in .357."
 	icon = 'mods/persistence/icons/obj/guns/tier1/revolver.dmi'
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	caliber = CALIBER_357
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
 	max_shells = 4

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/revolver/simple
+/obj/item/gun/projectile/revolver/tierone
 	name = ".357 'Chief' T1-RV"
 	desc = "Revolver of ancient design. Uses high-power rounds, but struggles with a low ammunition capacity and poor armor penetration. Chambered in .357."
 	icon = 'mods/persistence/icons/obj/guns/tier1/revolver.dmi'
@@ -17,5 +17,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/revolver/simple/empty
+/obj/item/gun/projectile/revolver/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/revolver.dm
@@ -4,7 +4,7 @@
 	icon = 'mods/persistence/icons/obj/guns/tier1/revolver.dmi'
 	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	caliber = CALIBER_357
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/simple
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tierone
 	max_shells = 4
 	w_class = ITEM_SIZE_NORMAL
 	fire_delay = 10

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/shotgun/simple
+/obj/item/gun/projectile/shotgun/tierone
 	name = "12g 'Bouncer' T1-SG"
 	desc = "Break-action shotgun of ancient design. Powerful, but struggles in prolonged engagements due to low ammo capacity. Can fire one or both chambers at a time. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_db.dmi'
@@ -25,5 +25,5 @@
 		list(mode_name="fire two barrels at a time", burst=2)
 	)
 
-/obj/item/gun/projectile/shotgun/simple/empty
+/obj/item/gun/projectile/shotgun/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/simple
-	name = "12g 'Bouncer' SG"
+	name = "12g 'Bouncer' T1-SG"
 	desc = "Break-action shotgun of ancient design. Powerful, but struggles in prolonged engagements due to low ammo capacity. Can fire one or both chambers at a time. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_db.dmi'
 	load_method = SINGLE_CASING
@@ -9,7 +9,7 @@
 	force = 10
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/simple
 	screen_shake = 1
 	accuracy = 0

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db.dm
@@ -10,7 +10,7 @@
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
 	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/simple
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tierone
 	screen_shake = 1
 	accuracy = 0
 	one_hand_penalty = 10

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db_sawn.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db_sawn.dm
@@ -1,11 +1,11 @@
 /obj/item/gun/projectile/shotgun/simple/sawnoff
-	name = "compact 12g 'Bouncer' SG"
+	name = "compact 12g 'Bouncer' T1-SG"
 	desc = "Break-action shotgun of ancient design. Powerful and can be worn on the waist, but struggles in prolonged engagements due to low ammo capacity and unwieldiness. Can fire one or both chambers at a time. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_db_sawn.dmi'
 	w_class = ITEM_SIZE_LARGE
 	force = 5
 	slot_flags = SLOT_LOWER_BODY|SLOT_BACK
-	origin_tech = "{'combat':3,'engineering':3,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	screen_shake = 2
 	accuracy = -1
 	one_hand_penalty = 15

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db_sawn.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_db_sawn.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/shotgun/simple/sawnoff
+/obj/item/gun/projectile/shotgun/tierone/sawnoff
 	name = "compact 12g 'Bouncer' T1-SG"
 	desc = "Break-action shotgun of ancient design. Powerful and can be worn on the waist, but struggles in prolonged engagements due to low ammo capacity and unwieldiness. Can fire one or both chambers at a time. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_db_sawn.dmi'
@@ -10,5 +10,5 @@
 	accuracy = -1
 	one_hand_penalty = 15
 
-/obj/item/gun/projectile/shotgun/simple/sawnoff/empty
+/obj/item/gun/projectile/shotgun/tierone/sawnoff/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump/simple
-	name = "12g 'Teufort' SG"
+	name = "12g 'Teufort' T1-SG"
 	desc = "Pump-action shotgun of ancient design. Powerful, but fires slowly due to pump-action mechanism and high recoil. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_pump.dmi'
 	max_shells = 5
@@ -8,7 +8,7 @@
 	force = 10
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
-	origin_tech = "{'combat':3,'engineering':2,'materials':2}"
+	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/simple
 	handle_casings = HOLD_CASINGS

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/shotgun/pump/simple
+/obj/item/gun/projectile/shotgun/pump/tierone
 	name = "12g 'Teufort' T1-SG"
 	desc = "Pump-action shotgun of ancient design. Powerful, but fires slowly due to pump-action mechanism and high recoil. Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier1/shotgun_pump.dmi'
@@ -19,5 +19,5 @@
 		/decl/material/solid/metal/titanium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/shotgun/pump/simple/empty
+/obj/item/gun/projectile/shotgun/pump/tierone/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier1/shotgun_pump.dm
@@ -10,7 +10,7 @@
 	caliber = CALIBER_12G
 	origin_tech = "{'combat':10,'engineering':10,'materials':4}"
 	load_method = SINGLE_CASING
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/simple
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tierone
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 10
 	material = /decl/material/solid/metal/steel

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/bolt_action/advanced
+/obj/item/gun/projectile/bolt_action/tiertwo
 	name = "5.56x45mm 'Deadshot' T2-BA"
 	desc = "Bolt-action rifle of modern design. Accurate, and comes with a built-in 2x scope alongside an increased ammunition capacity compared to earlier models. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier2/boltaction.dmi'
@@ -23,5 +23,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/bolt_action/advanced/empty
+/obj/item/gun/projectile/bolt_action/tiertwo/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
@@ -1,10 +1,10 @@
 /obj/item/gun/projectile/bolt_action/advanced
-	name = "5.56x45mm 'Deadshot' BA"
+	name = "5.56x45mm 'Deadshot' T2-BA"
 	desc = "Bolt-action rifle of modern design. Accurate, and comes with a built-in 2x scope alongside an increased ammunition capacity compared to earlier models. Chambered in 5.56x45mm."
 	icon = 'mods/persistence/icons/obj/guns/tier2/boltaction.dmi'
 	force = 10
 	slot_flags = SLOT_BACK
-	origin_tech = "{'combat':4,'engineering':4,'materials':3}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	caliber = CALIBER_556
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/boltaction.dm
@@ -10,7 +10,7 @@
 	load_method = SINGLE_CASING
 	max_shells = 7
 	w_class = ITEM_SIZE_HUGE
-	ammo_type = /obj/item/ammo_casing/fivefiftysix
+	ammo_type = /obj/item/ammo_casing/fivefiftysix/tiertwo
 	one_hand_penalty = 10
 	fire_delay = 10
 	accuracy = 2

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/advanced
+/obj/item/gun/projectile/pistol/tiertwo
 	name = ".45 'Paco' T2-HG"
 	desc = "Pistol of modern design. Highly accurate, and boasts a reduced fire delay compared to earlier models. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier2/pistol.dmi'
@@ -19,5 +19,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/pistol/advanced/empty
+/obj/item/gun/projectile/pistol/tiertwo/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/pistol/advanced
-	name = ".45 'Paco' HG"
+	name = ".45 'Paco' T2-HG"
 	desc = "Pistol of modern design. Highly accurate, and boasts a reduced fire delay compared to earlier models. Chambered in .45."
 	icon = 'mods/persistence/icons/obj/guns/tier2/pistol.dmi'
 	caliber = CALIBER_45
@@ -7,7 +7,7 @@
 	force = 5
 	accuracy = 2
 	one_hand_penalty = 1
-	origin_tech = "{'combat':4,'engineering':3,'materials':4}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	magazine_type = /obj/item/ammo_magazine/fortyfive/advanced

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol.dm
@@ -10,7 +10,7 @@
 	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_NORMAL
-	magazine_type = /obj/item/ammo_magazine/fortyfive/advanced
+	magazine_type = /obj/item/ammo_magazine/fortyfive/tiertwo
 	allowed_magazines = /obj/item/ammo_magazine/fortyfive
 	material = /decl/material/solid/metal/titanium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/pistol/pistol_pocket/advanced
+/obj/item/gun/projectile/pistol/pistol_pocket/tiertwo
 	name = ".22LR 'Triple-Threat' T2-HG"
 	desc = "Pistol of modern design. Small enough to store in pockets, and possesses both semi-automatic and three-round burst fire modes. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier2/pistol_pocket.dmi'
@@ -23,5 +23,5 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=2, one_hand_penalty=1, burst_accuracy=list(1,0,-1),       dispersion=list(0.0, 1.6, 2.4, 2.4)),
 	)
 
-/obj/item/gun/projectile/pistol/pistol_pocket/advanced/empty
+/obj/item/gun/projectile/pistol/pistol_pocket/tiertwo/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
@@ -1,12 +1,12 @@
 /obj/item/gun/projectile/pistol/pistol_pocket/advanced
-	name = ".22LR 'Triple-Threat' HG"
+	name = ".22LR 'Triple-Threat' T2-HG"
 	desc = "Pistol of modern design. Small enough to store in pockets, and possesses both semi-automatic and three-round burst fire modes. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier2/pistol_pocket.dmi'
 	fire_delay = 2
 	force = 5
 	accuracy = 1
 	one_hand_penalty = 0
-	origin_tech = "{'combat':4,'engineering':4,'materials':4}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_SMALL

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/pistol_pocket.dm
@@ -10,7 +10,7 @@
 	caliber = CALIBER_22LR
 	ammo_indicator = FALSE
 	w_class = ITEM_SIZE_SMALL
-	magazine_type = /obj/item/ammo_magazine/twentytwolr/advanced
+	magazine_type = /obj/item/ammo_magazine/twentytwolr/tiertwo
 	allowed_magazines = /obj/item/ammo_magazine/twentytwolr
 	material = /decl/material/solid/metal/titanium
 	matter = list(

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
@@ -1,8 +1,8 @@
 /obj/item/gun/projectile/revolver/advanced
-	name = ".357 'Officer' RV"
+	name = ".357 'Officer' T2-RV"
 	desc = "Revolver of modern design. Uses high-power rounds and has better ammunition capacity and accuracy compared to older models. Chambered in .357."
 	icon = 'mods/persistence/icons/obj/guns/tier2/revolver.dmi'
-	origin_tech = "{'combat':4,'engineering':3,'materials':4}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	caliber = CALIBER_357
 	ammo_type = /obj/item/ammo_casing/threefiftyseven/advanced
 	max_shells = 5

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/revolver/advanced
+/obj/item/gun/projectile/revolver/tiertwo
 	name = ".357 'Officer' T2-RV"
 	desc = "Revolver of modern design. Uses high-power rounds and has better ammunition capacity and accuracy compared to older models. Chambered in .357."
 	icon = 'mods/persistence/icons/obj/guns/tier2/revolver.dmi'
@@ -18,5 +18,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/revolver/advanced/empty
+/obj/item/gun/projectile/revolver/tiertwo/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/revolver.dm
@@ -4,7 +4,7 @@
 	icon = 'mods/persistence/icons/obj/guns/tier2/revolver.dmi'
 	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	caliber = CALIBER_357
-	ammo_type = /obj/item/ammo_casing/threefiftyseven/advanced
+	ammo_type = /obj/item/ammo_casing/threefiftyseven/tiertwo
 	max_shells = 5
 	w_class = ITEM_SIZE_NORMAL
 	fire_delay = 10

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump/advanced
-	name = "12g 'Gladdy' SG"
+	name = "12g 'Gladdy' T2-SG"
 	desc = "Pump-action shotgun of modern design. Possesses an increased ammunition capacity and shorter fire delay compared to earlier models . Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier2/shotgun_pump.dmi'
 	max_shells = 7
@@ -8,7 +8,7 @@
 	force = 10
 	slot_flags = SLOT_BACK
 	caliber = CALIBER_12G
-	origin_tech = "{'combat':4,'engineering':3,'materials':4}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	load_method = SINGLE_CASING
 	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/advanced
 	handle_casings = HOLD_CASINGS

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/shotgun/pump/advanced
+/obj/item/gun/projectile/shotgun/pump/tiertwo
 	name = "12g 'Gladdy' T2-SG"
 	desc = "Pump-action shotgun of modern design. Possesses an increased ammunition capacity and shorter fire delay compared to earlier models . Chambered in 12 gauge."
 	icon = 'mods/persistence/icons/obj/guns/tier2/shotgun_pump.dmi'
@@ -20,5 +20,5 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/gun/projectile/shotgun/pump/advanced/empty
+/obj/item/gun/projectile/shotgun/pump/tiertwo/empty
 	starts_loaded = FALSE

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/shotgun_pump.dm
@@ -10,7 +10,7 @@
 	caliber = CALIBER_12G
 	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	load_method = SINGLE_CASING
-	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/advanced
+	ammo_type = /obj/item/ammo_casing/twelvegauge/slug/tiertwo
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 10
 	material = /decl/material/solid/metal/titanium

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/automatic/smg/advanced
+/obj/item/gun/projectile/automatic/smg/tiertwo
 	name = ".22LR 'Junior' T2-SMG"
 	desc = "Submachine gun of modern design. Somewhat accurate, and boasts both semi-automatic and fully automatic firing modes. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier2/smg.dmi'
@@ -25,6 +25,6 @@
 		list(mode_name="fully-automatic",      burst=1, fire_delay=0,    burst_delay=1,      one_hand_penalty=15,                 burst_accuracy=list(0,-1,-1,-2,-3), dispersion=list(1.6, 1.6, 2.0, 2.0, 2.4), autofire_enabled=1)
 	)
 
-/obj/item/gun/projectile/automatic/smg/advanced/empty
+/obj/item/gun/projectile/automatic/smg/tiertwo/empty
 	starts_loaded = FALSE
 

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/smg/advanced
-	name = ".22LR 'Junior' SMG"
+	name = ".22LR 'Junior' T2-SMG"
 	desc = "Submachine gun of modern design. Somewhat accurate, and boasts both semi-automatic and fully automatic firing modes. Chambered in .22LR."
 	icon = 'mods/persistence/icons/obj/guns/tier2/smg.dmi'
 	caliber = CALIBER_22LR
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_LARGE
 	slot_flags = SLOT_LOWER_BODY|SLOT_BACK
 	force = 5
-	origin_tech = "{'combat':4,'engineering':4,'materials':3}"
+	origin_tech = "{'combat':15,'engineering':15,'materials':6}"
 	one_hand_penalty = 0
 	accuracy = 0
 	auto_eject = 0

--- a/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
+++ b/mods/persistence/modules/projectiles/guns/projectile/tier2/smg.dm
@@ -11,7 +11,7 @@
 	one_hand_penalty = 0
 	accuracy = 0
 	auto_eject = 0
-	magazine_type = /obj/item/ammo_magazine/twentytwolr/advanced
+	magazine_type = /obj/item/ammo_magazine/twentytwolr/tiertwo
 	allowed_magazines = /obj/item/ammo_magazine/twentytwolr
 	material = /decl/material/solid/metal/titanium
 	matter = list(


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
After some looking during the test, I noticed that advanced firearms were way too easy to produce easily and en-mass.

This increases their tech levels so that T0 weapons have 2 design stipulations, T1 weapons have 3 design stipulations, and T2 weapons have 4. This makes mass-producing guns a more specialized field rather than something anyone with an RND rig can do flippantly.

Ammunition is 1 design stipulation for T0, 2 for T1, and 3 for T2.

This PR also adds a 'T#' component to the name of each gun (T1-RV, for example) to make it easy to tell which tier the gun is from when looking at it in the research menu.

This PR also changes the titles used in each items atompath from 'simple/handmade/advanced' to 'tierzero/tierone/tiertwo' to make it clearer to see what tier each gun or ammo was from when spawning them in via game-panel.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Making guns more complicated to get increases their value significantly and reduces the amount of people having them

## Authorship
<!-- Describe original authors of changes to credit them. -->
genessee

## Changelog
:cl:
tweak: Guns now require more research.
tweak: Guns now have a 'T#' component in their names to more clearly indicate which tier they hail from.
tweak: Guns and ammunitions now have clearer atompath names to indicate their tier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->