### PR TITLE
Fix battery rack trying to use apc power

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -15,11 +15,14 @@
 	build_path = /obj/machinery/power/smes/batteryrack
 	board_type = "machine"
 	origin_tech = "{'powerstorage':3,'engineering':2}"
-	req_components = list(/obj/item/stock_parts/capacitor/ = 3, /obj/item/stock_parts/matter_bin/ = 1)
+	req_components = list(
+		/obj/item/stock_parts/capacitor/ = 3,
+		/obj/item/stock_parts/matter_bin/ = 1,
+	)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/console_screen = 1,
 		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/apc/buildable = 1
+		/obj/item/stock_parts/shielding/electric = 1,
 	)
 
 /obj/item/stock_parts/circuitboard/recharger
@@ -82,7 +85,7 @@
 		/obj/item/stock_parts/matter_bin = 3
 	)
 	additional_spawn_components = list(
-		/obj/item/stock_parts/power/apc/buildable = 1	
+		/obj/item/stock_parts/power/apc/buildable = 1
 	)
 
 /obj/item/stock_parts/circuitboard/big_turbine/center
@@ -110,7 +113,7 @@
 		/obj/item/stock_parts/matter_bin = 3
 	)
 	additional_spawn_components = list(
-		/obj/item/stock_parts/power/apc/buildable = 1		
+		/obj/item/stock_parts/power/apc/buildable = 1
 	)
 
 /obj/item/stock_parts/circuitboard/teg_turbine/motor


### PR DESCRIPTION
Since the battery rack is based on the smes, it can't pull power from apc components properly. So, I removed the apc component, and replaced it with the shielding element that was in the base smess but not in the battery rack.
