### PR TITLE
Make alarms reset to exchange not scrub

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -405,7 +405,7 @@
 	switch(mode)
 		if(AALARM_MODE_SCRUBBING)
 			for(var/device_id in alarm_area.air_scrub_names)
-				send_signal(device_id, list("set_power"= 1, "set_scrub_gas" = list(/decl/material/gas/carbon_dioxide = 1), "set_scrubbing"= SCRUBBER_SCRUB, "panic_siphon"= 0) )
+				send_signal(device_id, list("set_power"= 1, "set_scrub_gas" = list(/decl/material/gas/carbon_dioxide = 1), "set_scrubbing"= SCRUBBER_EXCHANGE, "panic_siphon"= 0) )
 			for(var/device_id in alarm_area.air_vent_names)
 				send_signal(device_id, list("set_power"= 1, "set_checks"= "default", "set_external_pressure"= "default") )
 


### PR DESCRIPTION
## Description of changes
Air alarms now resets the status of scrubber vents to `exchange` instead of `scrub`. Scrub is only useful for use inside tanks and burn chambers. Not for maintaining a breathable ratio of air inside rooms. Exchange is there for that.

## Changelog
:cl:
bugfix: Air alarms will now reset scrubber vents to exchange mode, and not scrub by default. So no more rooms becoming unbreathable randomly.
/:cl:
